### PR TITLE
Centralize frontend API base configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,4 @@ S3_SECRET_KEY=minio12345
 S3_BUCKET=tijaralink
 JWT_SECRET=dev-only
 # WEB
-NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_API_BASE=http://localhost:3001

--- a/apps/web/app/components/NewRfqForm.tsx
+++ b/apps/web/app/components/NewRfqForm.tsx
@@ -3,43 +3,43 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { API_BASE } from "@/lib/api";
+
 export default function NewRfqForm() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
-  const API_BASE =
-    process.env.NEXT_PUBLIC_API_BASE || "http://localhost:3001";
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-  e.preventDefault();
-  setLoading(true);
+    e.preventDefault();
+    setLoading(true);
 
-  // خُزّن المرجع قبل أي await
-  const formEl = e.currentTarget;
+    // خُزّن المرجع قبل أي await
+    const formEl = e.currentTarget;
 
-  const form = new FormData(formEl);
-  const payload = {
-    title: form.get("title"),
-    details: form.get("details"),
-    destinationCountry: form.get("dest") || "PS",
-  };
+    const form = new FormData(formEl);
+    const payload = {
+      title: form.get("title"),
+      details: form.get("details"),
+      destinationCountry: form.get("dest") || "PS",
+    };
 
-  const res = await fetch(`${API_BASE}/rfq`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
+    const res = await fetch(`${API_BASE}/rfq`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
 
-  setLoading(false);
+    setLoading(false);
 
-  if (!res.ok) {
-    alert("Failed to create RFQ");
-    return;
+    if (!res.ok) {
+      alert("Failed to create RFQ");
+      return;
+    }
+
+    router.refresh();
+    // امسح الحقول بأمان
+    formEl.reset();
   }
-
-  router.refresh();
-  // امسح الحقول بأمان
-  formEl.reset();
-}
 
 
   return (

--- a/apps/web/app/orders/[id]/OrderPageClient.tsx
+++ b/apps/web/app/orders/[id]/OrderPageClient.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
+import { API_BASE } from "@/lib/api";
+
 type Shipment = {
   id: string;
   mode: string;
@@ -66,7 +68,7 @@ export default function OrderPageClient({ order }: { order: Order }) {
               <form
                 onSubmit={async (e) => {
                   e.preventDefault();
-                  await fetch(`http://localhost:3001/orders/${order.id}/escrow/release`, {
+                  await fetch(`${API_BASE}/orders/${order.id}/escrow/release`, {
                     method: "POST",
                   });
                   router.refresh();
@@ -94,7 +96,7 @@ export default function OrderPageClient({ order }: { order: Order }) {
               const tracking = (form.elements.namedItem("tracking") as HTMLInputElement).value ||
                 "TRK-CLIENT";
               const mode = (form.elements.namedItem("mode") as HTMLSelectElement).value || "SEA";
-              await fetch(`http://localhost:3001/orders/${order.id}/shipments`, {
+              await fetch(`${API_BASE}/orders/${order.id}/shipments`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ mode, trackingNumber: tracking }),
@@ -128,7 +130,7 @@ export default function OrderPageClient({ order }: { order: Order }) {
                 <button
                   className="px-2 py-1 rounded border"
                   onClick={async () => {
-                    await fetch(`http://localhost:3001/shipments/${s.id}/status`, {
+                    await fetch(`${API_BASE}/shipments/${s.id}/status`, {
                       method: "POST",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify({ status: "AT_CUSTOMS" }),
@@ -146,7 +148,7 @@ export default function OrderPageClient({ order }: { order: Order }) {
                       data: { hsCode: "7208.38", docs: ["invoice.pdf"] },
                       status: "SUBMITTED",
                     };
-                    await fetch(`http://localhost:3001/shipments/${s.id}/customs`, {
+                    await fetch(`${API_BASE}/shipments/${s.id}/customs`, {
                       method: "POST",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify(payload),
@@ -160,7 +162,7 @@ export default function OrderPageClient({ order }: { order: Order }) {
                 <button
                   className="px-2 py-1 rounded border"
                   onClick={async () => {
-                    await fetch(`http://localhost:3001/shipments/${s.id}/status`, {
+                    await fetch(`${API_BASE}/shipments/${s.id}/status`, {
                       method: "POST",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify({ status: "DELIVERED" }),
@@ -182,7 +184,7 @@ export default function OrderPageClient({ order }: { order: Order }) {
           <button
             className="px-3 py-1.5 rounded border"
             onClick={async () => {
-              const r = await fetch(`http://localhost:3001/contracts/order/${order.id}`, {
+              const r = await fetch(`${API_BASE}/contracts/order/${order.id}`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ terms: "Basic TijaraLink contract terms v1" }),
@@ -205,7 +207,7 @@ export default function OrderPageClient({ order }: { order: Order }) {
               <button
                 className="px-2 py-1 rounded border"
                 onClick={async () => {
-                  await fetch(`http://localhost:3001/contracts/${order.contract?.id}/sign`, {
+                  await fetch(`${API_BASE}/contracts/${order.contract?.id}/sign`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({ role: "buyer" }),
@@ -218,7 +220,7 @@ export default function OrderPageClient({ order }: { order: Order }) {
               <button
                 className="px-2 py-1 rounded border"
                 onClick={async () => {
-                  await fetch(`http://localhost:3001/contracts/${order.contract?.id}/sign`, {
+                  await fetch(`${API_BASE}/contracts/${order.contract?.id}/sign`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({ role: "supplier" }),
@@ -242,7 +244,7 @@ export default function OrderPageClient({ order }: { order: Order }) {
             const form = e.currentTarget;
             const rating = Number((form.elements.namedItem("rating") as HTMLInputElement).value || 5);
             const comment = (form.elements.namedItem("comment") as HTMLInputElement).value || "";
-            await fetch(`http://localhost:3001/orders/${order.id}/review`, {
+            await fetch(`${API_BASE}/orders/${order.id}/review`, {
               method: "PUT",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ rating, comment }),

--- a/apps/web/app/orders/[id]/page.tsx
+++ b/apps/web/app/orders/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { API_BASE } from "@/lib/api";
 import OrderPageClient from "./OrderPageClient";
 
 async function fetchJSON(url: string, init?: RequestInit) {
@@ -10,7 +11,7 @@ async function fetchJSON(url: string, init?: RequestInit) {
 
 export default async function OrderPage({ params }: { params: { id: string } }) {
   const id = params.id;
-  const order = await fetchJSON(`http://localhost:3001/orders/${id}`).catch(() => null);
+  const order = await fetchJSON(`${API_BASE}/orders/${id}`).catch(() => null);
 
   if (!order) {
     return (

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,8 +1,6 @@
 import Link from "next/link";
+import { API_BASE } from "@/lib/api";
 import NewRfqForm from "./components/NewRfqForm";
-
-const API_BASE =
-  process.env.API_BASE || process.env.NEXT_PUBLIC_API_BASE || "http://localhost:3001";
 
 async function listRfq() {
   const res = await fetch(`${API_BASE}/rfq`, { cache: "no-store" });
@@ -35,7 +33,7 @@ export default async function Home() {
       <NewRfqForm />
 
       <div className="text-sm text-gray-500">
-        API: <Link href="http://localhost:3001/health">/health</Link>
+        API: <Link href={`${API_BASE}/health`}>/health</Link>
       </div>
     </main>
   );

--- a/apps/web/app/rfq/[id]/RfqPageClient.tsx
+++ b/apps/web/app/rfq/[id]/RfqPageClient.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
+import { API_BASE } from "@/lib/api";
+
 type Quote = {
   id: string;
   currency?: string;
@@ -62,7 +64,7 @@ export default function RfqPageClient({ rfq, quotes }: { rfq: Rfq; quotes: Quote
                   method="post"
                   onSubmit={async (e) => {
                     e.preventDefault();
-                    await fetch(`http://localhost:3001/quotes/${q.id}/accept`, { method: "POST" });
+                    await fetch(`${API_BASE}/quotes/${q.id}/accept`, { method: "POST" });
                     router.refresh();
                   }}
                 >
@@ -76,7 +78,7 @@ export default function RfqPageClient({ rfq, quotes }: { rfq: Rfq; quotes: Quote
                   method="post"
                   onSubmit={async (e) => {
                     e.preventDefault();
-                    await fetch(`http://localhost:3001/orders`, {
+                    await fetch(`${API_BASE}/orders`, {
                       method: "POST",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify({

--- a/apps/web/app/rfq/[id]/page.tsx
+++ b/apps/web/app/rfq/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { API_BASE } from "@/lib/api";
 import RfqPageClient from "./RfqPageClient";
 
 async function fetchJSON(url: string, init?: RequestInit) {
@@ -8,7 +9,7 @@ async function fetchJSON(url: string, init?: RequestInit) {
 
 export default async function RfqPage({ params }: { params: { id: string } }) {
   const id = params.id;
-  const rfq = await fetchJSON(`http://localhost:3001/rfq`).then((arr) =>
+  const rfq = await fetchJSON(`${API_BASE}/rfq`).then((arr) =>
     (arr as any[]).find((r) => r.id === id)
   );
   if (!rfq) {
@@ -19,7 +20,7 @@ export default async function RfqPage({ params }: { params: { id: string } }) {
     );
   }
 
-  const quotes = await fetchJSON(`http://localhost:3001/quotes/rfq/${id}`).catch(() => []);
+  const quotes = await fetchJSON(`${API_BASE}/quotes/rfq/${id}`).catch(() => []);
 
   return <RfqPageClient rfq={rfq} quotes={quotes} />;
 }

--- a/apps/web/app/rfq/page.tsx
+++ b/apps/web/app/rfq/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 import { useEffect, useState } from 'react'
 
+import { API_BASE } from '@/lib/api'
+
 type Rfq = { id: string; title: string; status: string }
 
 export default function RFQList() {
@@ -8,7 +10,7 @@ export default function RFQList() {
   const [err, setErr] = useState<string | null>(null)
 
   useEffect(() => {
-    const url = (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001') + '/rfq';
+    const url = `${API_BASE}/rfq`;
     fetch(url)
       .then(async (r) => {
         const data = await r.json().catch(() => (null))

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,6 +1,7 @@
-const BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || "http://localhost:3001";
 
-async function json<T>(res: Response): Promise<T> {
+async function json<T = any>(res: Response): Promise<T> {
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(`API ${res.status}: ${text || res.statusText}`);
@@ -18,22 +19,22 @@ function ensureNoError<T extends Record<string, any>>(data: T): T {
 export const api = {
   // المستخدمة في app/page.tsx
   async listRfq(): Promise<Array<{ id: string; title: string; status: string; destinationCountry: string; createdAt: string }>> {
-    const res = await fetch(`${BASE}/rfq`, { cache: "no-store" });
+    const res = await fetch(`${API_BASE}/rfq`, { cache: "no-store" });
     return json(res);
   },
 
   // أمثلة إضافية إن حبيت تستعملها لاحقًا:
   async listQuotes(rfqId: string) {
-    const res = await fetch(`${BASE}/quotes/rfq/${rfqId}`, { cache: "no-store" });
+    const res = await fetch(`${API_BASE}/quotes/rfq/${rfqId}`, { cache: "no-store" });
     return json(res);
   },
   async acceptQuote(id: string) {
-    const res = await fetch(`${BASE}/quotes/${id}/accept`, { method: "POST" });
+    const res = await fetch(`${API_BASE}/quotes/${id}/accept`, { method: "POST" });
     return json(res);
   },
 
   async createOrder(payload: { quoteId: string; totalMinor?: number; totalCurrency?: string }) {
-    const res = await fetch(`${BASE}/orders`, {
+    const res = await fetch(`${API_BASE}/orders`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
@@ -42,17 +43,17 @@ export const api = {
   },
 
   async getOrder(id: string) {
-    const res = await fetch(`${BASE}/orders/${id}`, { cache: "no-store" });
+    const res = await fetch(`${API_BASE}/orders/${id}`, { cache: "no-store" });
     return ensureNoError(await json(res));
   },
 
   async releaseEscrow(orderId: string) {
-    const res = await fetch(`${BASE}/orders/${orderId}/escrow/release`, { method: "POST" });
+    const res = await fetch(`${API_BASE}/orders/${orderId}/escrow/release`, { method: "POST" });
     return ensureNoError(await json(res));
   },
 
   async createShipment(orderId: string, payload: { mode?: string; trackingNumber?: string; tracking?: string }) {
-    const res = await fetch(`${BASE}/orders/${orderId}/shipments`, {
+    const res = await fetch(`${API_BASE}/orders/${orderId}/shipments`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
@@ -61,7 +62,7 @@ export const api = {
   },
 
   async setShipmentStatus(shipmentId: string, status: string) {
-    const res = await fetch(`${BASE}/shipments/${shipmentId}/status`, {
+    const res = await fetch(`${API_BASE}/shipments/${shipmentId}/status`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ status }),
@@ -70,7 +71,7 @@ export const api = {
   },
 
   async createCustoms(shipmentId: string, payload: { data?: Record<string, any>; status?: string | null }) {
-    const res = await fetch(`${BASE}/shipments/${shipmentId}/customs`, {
+    const res = await fetch(`${API_BASE}/shipments/${shipmentId}/customs`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
@@ -79,7 +80,7 @@ export const api = {
   },
 
   async updateCustomsStatus(customsId: string, status: string) {
-    const res = await fetch(`${BASE}/customs/${customsId}/status`, {
+    const res = await fetch(`${API_BASE}/customs/${customsId}/status`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ status }),
@@ -88,7 +89,7 @@ export const api = {
   },
 
   async createContract(orderId: string, terms: string) {
-    const res = await fetch(`${BASE}/contracts/order/${orderId}`, {
+    const res = await fetch(`${API_BASE}/contracts/order/${orderId}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ terms }),
@@ -97,7 +98,7 @@ export const api = {
   },
 
   async signContract(contractId: string, role: "buyer" | "supplier") {
-    const res = await fetch(`${BASE}/contracts/${contractId}/sign`, {
+    const res = await fetch(`${API_BASE}/contracts/${contractId}/sign`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ role }),
@@ -106,7 +107,7 @@ export const api = {
   },
 
   async upsertReview(orderId: string, rating: number, comment: string) {
-    const res = await fetch(`${BASE}/orders/${orderId}/review`, {
+    const res = await fetch(`${API_BASE}/orders/${orderId}/review`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ rating, comment }),


### PR DESCRIPTION
## Summary
- export a shared `API_BASE` constant backed by `NEXT_PUBLIC_API_BASE` and reuse it for all web API requests
- update RFQ and order pages, forms, and client actions to call the configured API host instead of hardcoding localhost
- document the `NEXT_PUBLIC_API_BASE` variable in `.env.example`

## Testing
- pnpm --filter @tijaralink/web build

------
https://chatgpt.com/codex/tasks/task_e_68e075370808832d839392880cd1a11b