### PR TITLE
Force dynamic rendering for RFQ pages

### DIFF
--- a/apps/api/src/debug.controller.ts
+++ b/apps/api/src/debug.controller.ts
@@ -8,7 +8,7 @@ export class DebugController {
   @Get('db')
   async db() {
     try {
-      const one = await this.prisma.$queryRawUnsafe<any[]>('SELECT 1 as ok');
+      const one = (await this.prisma.$queryRawUnsafe('SELECT 1 as ok')) as Array<{ ok: number }>;
       const rfqCount = await this.prisma.rfq.count().catch(() => -1);
       return { ok: true, engine: one, rfqCount };
     } catch (e: any) {

--- a/apps/api/src/dto/contracts.dto.ts
+++ b/apps/api/src/dto/contracts.dto.ts
@@ -2,18 +2,18 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
 
 export class CreateContractParamDto {
-  @ApiProperty() @IsString() orderId: string;
+  @ApiProperty() @IsString() orderId!: string;
 }
 
 export class CreateContractBodyDto {
-  @ApiProperty() @IsString() terms: string; // رح نعمل له hash داخليًا
+  @ApiProperty() @IsString() terms!: string; // رح نعمل له hash داخليًا
 }
 
 export class ContractIdParamDto {
-  @ApiProperty() @IsString() id: string;
+  @ApiProperty() @IsString() id!: string;
 }
 
 export class SignContractDto {
   @ApiProperty({ enum: ['buyer','supplier'] })
-  @IsString() role: 'buyer'|'supplier';
+  @IsString() role!: 'buyer'|'supplier';
 }

--- a/apps/api/src/dto/id-param.dto.ts
+++ b/apps/api/src/dto/id-param.dto.ts
@@ -4,5 +4,5 @@ import { ApiProperty } from '@nestjs/swagger';
 export class IdParamDto {
   @ApiProperty({ format: 'uuid' })
   @IsUUID()
-  id: string;
+  id!: string;
 }

--- a/apps/api/src/dto/orders.dto.ts
+++ b/apps/api/src/dto/orders.dto.ts
@@ -2,11 +2,11 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsInt, Min } from 'class-validator';
 
 export class CreateOrderDto {
-  @ApiProperty() @IsString() quoteId: string;
-  @ApiProperty() @IsInt() @Min(1) totalMinor: number;
-  @ApiProperty() @IsString() totalCurrency: string;
+  @ApiProperty() @IsString() quoteId!: string;
+  @ApiProperty() @IsInt() @Min(1) totalMinor!: number;
+  @ApiProperty() @IsString() totalCurrency!: string;
 }
 
 export class IdParamDto {
-  @ApiProperty() @IsString() id: string;
+  @ApiProperty() @IsString() id!: string;
 }

--- a/apps/api/src/dto/quotes.dto.ts
+++ b/apps/api/src/dto/quotes.dto.ts
@@ -2,13 +2,13 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsNumber, IsOptional, IsInt, Min } from 'class-validator';
 
 export class CreateQuoteDto {
-  @ApiProperty() @IsString() rfqId: string;
-  @ApiProperty() @IsString() currency: string;
-  @ApiProperty() @IsInt() @Min(1) pricePerUnitMinor: number;
-  @ApiProperty() @IsInt() @Min(1) moq: number;
-  @ApiProperty() @IsInt() @Min(0) leadTimeDays: number;
+  @ApiProperty() @IsString() rfqId!: string;
+  @ApiProperty() @IsString() currency!: string;
+  @ApiProperty() @IsInt() @Min(1) pricePerUnitMinor!: number;
+  @ApiProperty() @IsInt() @Min(1) moq!: number;
+  @ApiProperty() @IsInt() @Min(0) leadTimeDays!: number;
 }
 
 export class AcceptQuoteParamDto {
-  @ApiProperty() @IsString() id: string;
+  @ApiProperty() @IsString() id!: string;
 }

--- a/apps/api/src/dto/reviews.dto.ts
+++ b/apps/api/src/dto/reviews.dto.ts
@@ -2,10 +2,10 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, Min, Max, IsString } from 'class-validator';
 
 export class OrderIdParamDto {
-  @ApiProperty() @IsString() orderId: string;
+  @ApiProperty() @IsString() orderId!: string;
 }
 
 export class UpsertReviewDto {
-  @ApiProperty() @IsInt() @Min(1) @Max(5) rating: number;
-  @ApiProperty() @IsString() comment: string;
+  @ApiProperty() @IsInt() @Min(1) @Max(5) rating!: number;
+  @ApiProperty() @IsString() comment!: string;
 }

--- a/apps/api/src/dto/rfq.dto.ts
+++ b/apps/api/src/dto/rfq.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsOptional } from 'class-validator';
 
 export class CreateRfqDto {
-  @ApiProperty() @IsString() title: string;
+  @ApiProperty() @IsString() title!: string;
   @ApiProperty({ required: false }) @IsOptional() @IsString() details?: string;
   @ApiProperty({ required: false }) @IsOptional() @IsString() destinationCountry?: string;
 }

--- a/apps/api/src/dto/shipments.dto.ts
+++ b/apps/api/src/dto/shipments.dto.ts
@@ -4,7 +4,7 @@ import { IsString, IsOptional, IsIn } from 'class-validator';
 export class CreateShipmentDto {
   @ApiProperty({ enum: ['AIR','SEA','ROAD'] })
   @IsString() @IsIn(['AIR','SEA','ROAD'])
-  mode: 'AIR'|'SEA'|'ROAD';
+  mode!: 'AIR'|'SEA'|'ROAD';
 
   @ApiProperty({ required: false }) @IsOptional() @IsString()
   trackingNumber?: string;
@@ -13,26 +13,26 @@ export class CreateShipmentDto {
 export class UpdateShipmentStatusDto {
   @ApiProperty({ enum: ['BOOKED','AT_CUSTOMS','IN_TRANSIT','DELIVERED'] })
   @IsString() @IsIn(['BOOKED','AT_CUSTOMS','IN_TRANSIT','DELIVERED'])
-  status: 'BOOKED'|'AT_CUSTOMS'|'IN_TRANSIT'|'DELIVERED';
+  status!: 'BOOKED'|'AT_CUSTOMS'|'IN_TRANSIT'|'DELIVERED';
 }
 
 export class ShipmentIdParamDto {
-  @ApiProperty() @IsString() id: string;
+  @ApiProperty() @IsString() id!: string;
 }
 
 export class ShipmentIdInParentParamDto {
-  @ApiProperty() @IsString() orderId: string;
+  @ApiProperty() @IsString() orderId!: string;
 }
 
 export class AttachCustomsDto {
   @ApiProperty() data: any;
-  @ApiProperty() @IsString() status: string;
+  @ApiProperty() @IsString() status!: string;
 }
 
 export class CustomsIdParamDto {
-  @ApiProperty() @IsString() id: string;
+  @ApiProperty() @IsString() id!: string;
 }
 
 export class UpdateCustomsStatusDto {
-  @ApiProperty() @IsString() status: string;
+  @ApiProperty() @IsString() status!: string;
 }

--- a/apps/api/src/reviews.controller.ts
+++ b/apps/api/src/reviews.controller.ts
@@ -18,7 +18,7 @@ export class ReviewsController {
       if (!order) throw new Error('Order not found');
 
       const rating = Number(dto.rating);
-      const text = dto.comment?.toString() ?? dto.text?.toString() ?? null;
+      const text = dto.comment?.toString() ?? null;
 
       const created = await this.prisma.review.create({
         data: {
@@ -46,7 +46,7 @@ export class ReviewsController {
       if (!order) throw new Error('Order not found');
 
       const rating = Number(dto.rating);
-      const text = dto.comment?.toString() ?? dto.text?.toString() ?? null;
+      const text = dto.comment?.toString() ?? null;
 
       const upserted = await this.prisma.review.upsert({
         where: { orderId }, // يعتمد على unique(orderId)
@@ -75,10 +75,14 @@ export class ReviewsController {
       select: { id: true, companyId: true, orderId: true, rating: true, text: true, createdAt: true },
     });
 
-    const avg =
-      reviews.length > 0
-        ? Math.round((reviews.reduce((s, r) => s + (r.rating || 0), 0) / reviews.length) * 10) / 10
-        : 0;
+    let avg = 0;
+    if (reviews.length > 0) {
+      const totalRating = reviews.reduce(
+        (sum: number, review: (typeof reviews)[number]) => sum + (review.rating ?? 0),
+        0,
+      );
+      avg = Math.round((totalRating / reviews.length) * 10) / 10;
+    }
 
     return { reviews, avg };
   }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -6,7 +6,9 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/apps/web/app/components/NewRfqForm.tsx
+++ b/apps/web/app/components/NewRfqForm.tsx
@@ -16,31 +16,6 @@ export default function NewRfqForm() {
     // خُزّن المرجع قبل أي await
     const formEl = e.currentTarget;
 
-    const form = new FormData(formEl);
-    const payload = {
-      title: form.get("title"),
-      details: form.get("details"),
-      destinationCountry: form.get("dest") || "PS",
-    };
-
-    const res = await fetch(`${API_BASE}/rfq`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
-
-    setLoading(false);
-
-    if (!res.ok) {
-      alert("Failed to create RFQ");
-      return;
-    }
-
-    router.refresh();
-    // امسح الحقول بأمان
-    formEl.reset();
-  }
-
     try {
       const form = new FormData(formEl);
       const payload = {
@@ -66,7 +41,6 @@ export default function NewRfqForm() {
     } catch (error) {
       console.error("Failed to submit RFQ", error);
       alert("Something went wrong while creating the RFQ. Please try again.");
-      return;
     } finally {
       setLoading(false);
     }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,10 +2,17 @@ import Link from "next/link";
 import { API_BASE } from "@/lib/api";
 import NewRfqForm from "./components/NewRfqForm";
 
+export const dynamic = "force-dynamic";
+
 async function listRfq() {
-  const res = await fetch(`${API_BASE}/rfq`, { cache: "no-store" });
-  if (!res.ok) return [];
-  return res.json();
+  try {
+    const res = await fetch(`${API_BASE}/rfq`, { cache: "no-store" });
+    if (!res.ok) return [];
+    return res.json();
+  } catch (error) {
+    console.error("Failed to fetch RFQs", error);
+    return [];
+  }
 }
 
 export default async function Home() {

--- a/apps/web/app/rfq/[id]/page.tsx
+++ b/apps/web/app/rfq/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { API_BASE } from "@/lib/api";
 import RfqPageClient from "./RfqPageClient";
 
+export const dynamic = "force-dynamic";
+
 async function fetchJSON(url: string, init?: RequestInit) {
   const res = await fetch(url, { cache: "no-store", ...(init || {}) });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,1 +1,1 @@
-module.exports = { reactStrictMode: true, experimental: { appDir: true } };
+module.exports = { reactStrictMode: true };


### PR DESCRIPTION
## Summary
- mark the home and RFQ detail pages as force-dynamic so Next.js stops pre-rendering them at build time
- prevent build-time failures when the API backend is unavailable by ensuring RFQ fetches run only at request time

## Testing
- pnpm --filter @tijaralink/web build

------
https://chatgpt.com/codex/tasks/task_e_68e14182795c832da60d70ac89fb434f