### PR TITLE
Revamp RFQ landing page with professional UI

### DIFF
--- a/apps/web/app/components/NewRfqForm.tsx
+++ b/apps/web/app/components/NewRfqForm.tsx
@@ -13,7 +13,6 @@ export default function NewRfqForm() {
     e.preventDefault();
     setLoading(true);
 
-    // خُزّن المرجع قبل أي await
     const formEl = e.currentTarget;
 
     try {
@@ -36,7 +35,6 @@ export default function NewRfqForm() {
       }
 
       router.refresh();
-      // امسح الحقول بأمان
       formEl.reset();
     } catch (error) {
       console.error("Failed to submit RFQ", error);
@@ -46,35 +44,56 @@ export default function NewRfqForm() {
     }
   }
 
-
   return (
-    <form onSubmit={onSubmit} className="space-y-3 border p-4 rounded-md">
-      <h2 className="font-semibold">Create RFQ</h2>
-      <div className="flex gap-2">
-        <input
-          name="title"
-          placeholder="Title"
-          className="border p-2 flex-1"
-          required
-        />
-        <input
-          name="details"
-          placeholder="Details"
-          className="border p-2 flex-1"
-        />
-        <input
-          name="dest"
-          placeholder="PS"
-          className="border p-2 w-28"
-          defaultValue="PS"
-        />
+    <form onSubmit={onSubmit} className="form">
+      <div className="form__field-group">
+        <div className="form__field">
+          <label className="form__label" htmlFor="rfq-title">
+            Project title
+          </label>
+          <input
+            id="rfq-title"
+            name="title"
+            placeholder="Example: Logistics support for Q3 expansion"
+            className="input"
+            required
+            disabled={loading}
+          />
+        </div>
+        <div className="form__field">
+          <label className="form__label" htmlFor="rfq-details">
+            Overview
+          </label>
+          <textarea
+            id="rfq-details"
+            name="details"
+            placeholder="Outline the scope, volumes, or any specifications suppliers should know."
+            className="textarea"
+            disabled={loading}
+          />
+        </div>
+        <div className="form__field">
+          <label className="form__label" htmlFor="rfq-destination">
+            Destination country
+          </label>
+          <input
+            id="rfq-destination"
+            name="dest"
+            placeholder="PS"
+            className="input"
+            defaultValue="PS"
+            disabled={loading}
+          />
+        </div>
       </div>
-      <button
-        disabled={loading}
-        className="bg-black text-white px-3 py-2 rounded"
-      >
-        {loading ? "Saving..." : "Create RFQ"}
-      </button>
+      <div className="form__footer">
+        <button type="submit" disabled={loading} className="button-primary">
+          {loading ? "Publishing..." : "Publish RFQ"}
+        </button>
+        <span className="form__hint">
+          Buyers are notified instantly. You can edit RFQ details anytime.
+        </span>
+      </div>
     </form>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,396 @@
+:root {
+  color-scheme: light;
+  --background: #f4f7fb;
+  --foreground: #0f172a;
+  --muted: #64748b;
+  --muted-soft: #94a3b8;
+  --accent: #2563eb;
+  --accent-strong: #1d4ed8;
+  --accent-soft: #dbeafe;
+  --card-bg: #ffffffcc;
+  --card-border: rgba(148, 163, 184, 0.2);
+  --shadow-lg: 0 20px 45px rgba(15, 23, 42, 0.08);
+  --shadow-md: 0 12px 30px rgba(15, 23, 42, 0.06);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --font-body: "Poppins", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  min-height: 100%;
+  background: linear-gradient(135deg, #eff6ff 0%, #e0f2fe 50%, #eef2ff 100%);
+  color: var(--foreground);
+  font-family: var(--font-body);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at top right, rgba(37, 99, 235, 0.14), transparent 45%),
+    radial-gradient(circle at bottom left, rgba(14, 165, 233, 0.18), transparent 40%);
+  z-index: -1;
+}
+
+main.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 64px 24px 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--card-border);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(18px);
+  padding: 32px;
+}
+
+.card--compact {
+  padding: 24px;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(37, 99, 235, 0.12), transparent 45%),
+    radial-gradient(circle at bottom left, rgba(14, 165, 233, 0.12), transparent 55%);
+  pointer-events: none;
+}
+
+.hero__content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 16px;
+  max-width: 680px;
+}
+
+.hero__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+  width: fit-content;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 13px;
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 4vw, 3.25rem);
+  margin: 0;
+  line-height: 1.1;
+}
+
+.hero__subtitle {
+  margin: 0;
+  font-size: 1.125rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.button-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 14px 26px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: white;
+  font-weight: 600;
+  font-size: 15px;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.35);
+  text-decoration: none;
+}
+
+.button-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 40px rgba(37, 99, 235, 0.45);
+}
+
+.button-primary[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.button-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: transparent;
+  color: var(--foreground);
+  font-weight: 600;
+  font-size: 15px;
+  text-decoration: none;
+  transition: background 150ms ease;
+}
+
+.button-secondary:hover {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 18px;
+}
+
+.stat-card {
+  background: white;
+  padding: 20px;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.stat-card__label {
+  color: var(--muted-soft);
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stat-card__value {
+  font-size: 1.875rem;
+  font-weight: 700;
+  margin-top: 8px;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 28px;
+}
+
+@media (min-width: 1000px) {
+  .layout-grid {
+    grid-template-columns: 2fr 1fr;
+  }
+}
+
+.table-wrapper {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(203, 213, 225, 0.6);
+  overflow: hidden;
+  background: white;
+}
+
+.rfq-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.rfq-table thead {
+  background: rgba(37, 99, 235, 0.06);
+  text-align: left;
+}
+
+.rfq-table th,
+.rfq-table td {
+  padding: 16px 20px;
+  font-size: 15px;
+}
+
+.rfq-table tbody tr:not(:last-child) {
+  border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  text-transform: capitalize;
+}
+
+.status-pill--pending {
+  background: rgba(250, 204, 21, 0.16);
+  color: #92400e;
+}
+
+.status-pill--approved,
+.status-pill--accepted,
+.status-pill--active {
+  background: rgba(34, 197, 94, 0.18);
+  color: #166534;
+}
+
+.status-pill--closed,
+.status-pill--cancelled,
+.status-pill--rejected {
+  background: rgba(248, 113, 113, 0.18);
+  color: #991b1b;
+}
+
+.status-pill--draft {
+  background: rgba(148, 163, 184, 0.18);
+  color: #475569;
+}
+
+.empty-state {
+  padding: 32px;
+  text-align: center;
+  color: var(--muted);
+  background: white;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+}
+
+.form-card__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.form-card__subtitle {
+  margin: 0 0 28px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.form {
+  display: grid;
+  gap: 20px;
+}
+
+.form__field-group {
+  display: grid;
+  gap: 16px;
+}
+
+.form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form__label {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.input,
+.textarea,
+.select {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 14px 16px;
+  font-size: 15px;
+  transition: border 150ms ease, box-shadow 150ms ease;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.input:focus,
+.textarea:focus,
+.select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+}
+
+.textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.form__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.form__hint {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.badge-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+a.link-muted {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+a.link-muted:hover {
+  text-decoration: underline;
+}
+
+.footer-note {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+@media (max-width: 640px) {
+  .card,
+  .card--compact {
+    padding: 24px;
+  }
+
+  .form__footer {
+    align-items: flex-start;
+  }
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,7 +1,24 @@
+import type { Metadata } from "next";
+import { Poppins } from "next/font/google";
+
+import "./globals.css";
+
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
+  display: "swap",
+});
+
+export const metadata: Metadata = {
+  title: "TijaraLink | Seamless RFQ Collaboration",
+  description:
+    "Streamline your request-for-quote workflow with TijaraLink. Track sourcing, collaborate with suppliers, and accelerate decisions.",
+};
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" dir="ltr">
-      <body className="min-h-screen antialiased">{children}</body>
+      <body className={poppins.className}>{children}</body>
     </html>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { API_BASE } from "@/lib/api";
 import NewRfqForm from "./components/NewRfqForm";
 
@@ -15,33 +14,174 @@ async function listRfq() {
   }
 }
 
+const statusClassName = (status: string | null | undefined) => {
+  const normalized = (status || "").toLowerCase();
+  if (/(approved|accepted|active|awarded)/.test(normalized)) {
+    return "status-pill status-pill--approved";
+  }
+  if (/(closed|cancelled|rejected|expired)/.test(normalized)) {
+    return "status-pill status-pill--closed";
+  }
+  if (/(pending|review|submitted)/.test(normalized)) {
+    return "status-pill status-pill--pending";
+  }
+  if (/(draft)/.test(normalized)) {
+    return "status-pill status-pill--draft";
+  }
+  return "status-pill status-pill--pending";
+};
+
+const formatDate = (value: string | null | undefined) => {
+  if (!value) return "—";
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "—";
+    return new Intl.DateTimeFormat("en", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(date);
+  } catch (error) {
+    return "—";
+  }
+};
+
 export default async function Home() {
   const rfqs = await listRfq();
+  const totalRfqs = rfqs.length;
+  const activeRfqs = rfqs.filter((r: any) =>
+    String(r.status || "").toLowerCase().match(/pending|review|submitted|active/)
+  ).length;
+  const fulfilledRfqs = rfqs.filter((r: any) =>
+    String(r.status || "").toLowerCase().match(/closed|awarded|completed|accepted/)
+  ).length;
 
   return (
-    <main className="max-w-3xl mx-auto p-6 space-y-6">
-      <h1 className="text-2xl font-bold">RFQs</h1>
+    <main className="page">
+      <section className="card hero">
+        <div className="hero__content">
+          <span className="hero__eyebrow">TijaraLink Platform</span>
+          <h1 className="hero__title">
+            Procurement visibility and supplier collaboration in one elegant hub.
+          </h1>
+          <p className="hero__subtitle">
+            Monitor every request-for-quote, engage trusted partners, and move from
+            sourcing to awarding with total confidence.
+          </p>
+          <div className="cta-row">
+            <a className="button-primary" href="#create-rfq">
+              Start a New RFQ
+            </a>
+            <a
+              className="button-secondary"
+              href={`${API_BASE}/health`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              API Health Endpoint
+            </a>
+          </div>
+        </div>
+        <div className="badge-inline" style={{ alignSelf: "flex-start" }}>
+          <span role="img" aria-hidden="true">
+            🔒
+          </span>
+          Secure workflows with escrow-ready orders
+        </div>
+      </section>
 
-      <ul className="space-y-3">
-        {rfqs.map((r: any) => (
-          <li key={r.id} className="border p-3 rounded">
-            <div className="font-medium">{r.title}</div>
-            <div className="text-sm text-gray-600">
-              Status: {r.status} — Dest: {r.destinationCountry}
+      <section className="stats-grid">
+        <div className="stat-card">
+          <div className="stat-card__label">Open RFQs</div>
+          <div className="stat-card__value">{activeRfqs}</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-card__label">Fulfilled</div>
+          <div className="stat-card__value">{fulfilledRfqs}</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-card__label">Total Requests</div>
+          <div className="stat-card__value">{totalRfqs}</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-card__label">API Endpoint</div>
+          <div className="stat-card__value" style={{ fontSize: "1rem" }}>
+            <a href={`${API_BASE}/rfq`} className="link-muted" target="_blank" rel="noreferrer">
+              /rfq
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section className="layout-grid">
+        <div className="card card--compact">
+          <div className="hero__content" style={{ maxWidth: "100%", gap: "8px" }}>
+            <span className="badge-inline" style={{ marginBottom: "12px" }}>
+              <span role="img" aria-hidden="true">
+                📊
+              </span>
+              Live Pipeline
+            </span>
+            <h2 className="hero__title" style={{ fontSize: "2rem" }}>
+              Active Requests for Quote
+            </h2>
+            <p className="hero__subtitle" style={{ fontSize: "1rem" }}>
+              Track statuses, due dates, and destinations at a glance.
+            </p>
+          </div>
+
+          {rfqs.length > 0 ? (
+            <div className="table-wrapper">
+              <table className="rfq-table">
+                <thead>
+                  <tr>
+                    <th>Title</th>
+                    <th>Status</th>
+                    <th>Destination</th>
+                    <th>Created</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rfqs.map((r: any) => (
+                    <tr key={r.id}>
+                      <td>{r.title}</td>
+                      <td>
+                        <span className={statusClassName(r.status)}>{r.status}</span>
+                      </td>
+                      <td>{r.destinationCountry || "—"}</td>
+                      <td>{formatDate(r.createdAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
-          </li>
-        ))}
-        {rfqs.length === 0 && (
-          <li className="text-sm text-gray-500">No RFQs yet.</li>
-        )}
-      </ul>
+          ) : (
+            <div className="empty-state">
+              <h3 style={{ marginBottom: "8px" }}>No RFQs yet</h3>
+              <p style={{ margin: 0 }}>
+                Create your first request to start collaborating with suppliers.
+              </p>
+            </div>
+          )}
+        </div>
 
-      {/* الفورم التفاعلي كمكوّن Client */}
-      <NewRfqForm />
-
-      <div className="text-sm text-gray-500">
-        API: <Link href={`${API_BASE}/health`}>/health</Link>
-      </div>
+        <aside id="create-rfq" className="card card--compact">
+          <div className="form-card__title">Launch a new RFQ</div>
+          <p className="form-card__subtitle">
+            Share your sourcing requirements with verified suppliers and receive
+            quotes without friction.
+          </p>
+          <NewRfqForm />
+          <p className="footer-note" style={{ marginTop: "24px" }}>
+            Need to integrate programmatically? Explore the
+            {" "}
+            <a href={`${API_BASE}/docs`} className="link-muted" target="_blank" rel="noreferrer">
+              developer docs
+            </a>
+            .
+          </p>
+        </aside>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add a global visual language, font setup, and gradients to the web app
- redesign the RFQ dashboard with hero, stats, and a polished table layout
- refresh the RFQ creation form with labeled fields and call-to-action styling

## Testing
- pnpm --filter @tijaralink/web build

------
https://chatgpt.com/codex/tasks/task_e_68e15c87416c832dae01e5fba1e7d199