### PR TITLE
feat: expose dashboards order listing endpoint

### DIFF
--- a/apps/web/app/admin/shipments/page.tsx
+++ b/apps/web/app/admin/shipments/page.tsx
@@ -14,12 +14,9 @@ function shipmentStatusBadge(status?: string | null) {
   return "status-pill status-pill--draft";
 }
 
-function normaliseCustoms(customs?: ApiCustoms[] | ApiCustoms | null): ApiCustoms | null {
-  if (!customs) return null;
-  if (Array.isArray(customs)) {
-    return customs[0] ?? null;
-  }
-  return customs;
+function normaliseCustoms(customs?: ApiCustoms[] | null): ApiCustoms | null {
+  if (!customs?.length) return null;
+  return customs[0] ?? null;
 }
 
 export default async function AdminShipmentsPage() {

--- a/apps/web/app/orders/[id]/page.tsx
+++ b/apps/web/app/orders/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import {
   api,
+  ApiCustoms,
   ApiOrder,
   ApiShipment,
 } from "@/lib/api";
@@ -40,6 +41,11 @@ function shipmentStatusBadge(status?: string | null) {
   if (/(delivered|cleared)/.test(normalized)) return "status-pill status-pill--approved";
   if (/(customs|hold)/.test(normalized)) return "status-pill status-pill--pending";
   return "status-pill status-pill--draft";
+}
+
+function firstCustoms(customs?: ApiCustoms[] | null): ApiCustoms | null {
+  if (!customs?.length) return null;
+  return customs[0] ?? null;
 }
 
 function ShipmentActions({ shipment }: { shipment: ApiShipment }) {
@@ -158,32 +164,34 @@ export default async function OrderPage({ params }: { params: { id: string } }) 
 
         {(order.shipments || []).length ? (
           <ul className="list-stack">
-            {order.shipments?.map((shipment) => (
-              <li key={shipment.id} className="shipment-card">
-                <div className="shipment-card__header">
-                  <div>
-                    <p className="eyebrow">Shipment #{shipment.id}</p>
-                    <h3>{shipment.mode || "Mode not set"}</h3>
+            {order.shipments?.map((shipment) => {
+              const customs = firstCustoms(shipment.customs);
+              return (
+                <li key={shipment.id} className="shipment-card">
+                  <div className="shipment-card__header">
+                    <div>
+                      <p className="eyebrow">Shipment #{shipment.id}</p>
+                      <h3>{shipment.mode || "Mode not set"}</h3>
+                    </div>
+                    <span className={shipmentStatusBadge(shipment.status)}>{shipment.status || "Pending"}</span>
                   </div>
-                  <span className={shipmentStatusBadge(shipment.status)}>{shipment.status || "Pending"}</span>
-                </div>
-                <p className="section-subtitle">Tracking: {shipment.tracking || "—"}</p>
-                <ShipmentActions shipment={shipment} />
+                  <p className="section-subtitle">Tracking: {shipment.tracking || "—"}</p>
+                  <ShipmentActions shipment={shipment} />
 
-                <div className="divider" />
+                  <div className="divider" />
 
-                <div className="shipment-card__customs">
-                  <h4>Customs declaration</h4>
-                  {shipment.customs ? (
-                    <div className="customs-summary">
-                      <p>
-                        Status: <strong>{shipment.customs.status || "SUBMITTED"}</strong>
-                      </p>
-                      <p>HS Code: {shipment.customs.data?.hsCode || "—"}</p>
-                      <p>Docs: {(shipment.customs.data?.docs || []).join(", ") || "—"}</p>
+                  <div className="shipment-card__customs">
+                    <h4>Customs declaration</h4>
+                    {customs ? (
+                      <div className="customs-summary">
+                        <p>
+                        Status: <strong>{customs.status || "SUBMITTED"}</strong>
+                        </p>
+                      <p>HS Code: {customs.data?.hsCode || "—"}</p>
+                      <p>Docs: {(customs.data?.docs || []).join(", ") || "—"}</p>
                       <div className="stack-horizontal">
                         <SetCustomsStatusButton
-                          customsId={shipment.customs.id}
+                          customsId={customs.id}
                           status="CLEARED"
                           label="Mark customs cleared"
                         />
@@ -192,10 +200,11 @@ export default async function OrderPage({ params }: { params: { id: string } }) 
                   ) : (
                     <p className="section-subtitle">No customs declaration linked yet.</p>
                   )}
-                  <AttachCustomsForm shipmentId={shipment.id} customs={shipment.customs} />
+                  <AttachCustomsForm shipmentId={shipment.id} customs={customs} />
                 </div>
               </li>
-            ))}
+            );
+          })}
           </ul>
         ) : (
           <div className="empty-state" style={{ marginTop: "1rem" }}>

--- a/apps/web/app/suppliers/[companyId]/reviews/page.tsx
+++ b/apps/web/app/suppliers/[companyId]/reviews/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { api, ApiReview } from "@/lib/api";
+import { api, ApiReview, SupplierReviewsPayload } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
 
@@ -24,17 +24,19 @@ function averageRating(reviews: ApiReview[]) {
 export default async function SupplierReviewsPage({ params }: { params: { companyId: string } }) {
   const { companyId } = params;
 
+  let payload: SupplierReviewsPayload | null = null;
   let reviews: ApiReview[] = [];
   let error: string | null = null;
 
   try {
-    reviews = await api.listSupplierReviews(companyId);
+    payload = await api.listSupplierReviews(companyId);
+    reviews = payload.reviews;
   } catch (err) {
     console.error("Failed to load supplier reviews", err);
     error = (err as Error)?.message || "Unable to load reviews";
   }
 
-  const average = averageRating(reviews);
+  const average = payload?.avg ?? averageRating(reviews);
 
   return (
     <main className="detail-page">

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -54,28 +54,34 @@ export type ApiQuote = {
 };
 
 export type ApiEscrow = {
+  id: string;
   released: boolean;
   heldMinor: number;
   currency: string;
+  createdAt?: string;
+};
+
+export type ApiCustomsData = {
+  hsCode?: string;
+  docs?: string[];
+  [key: string]: unknown;
 };
 
 export type ApiCustoms = {
   id: string;
+  shipmentId?: string;
   status?: string | null;
-  data?: {
-    hsCode?: string;
-    docs?: string[];
-  } | null;
-  submittedAt?: string | null;
-  clearedAt?: string | null;
+  data?: ApiCustomsData | null;
 };
 
 export type ApiShipment = {
   id: string;
+  orderId?: string | null;
   mode?: string | null;
   tracking?: string | null;
   status?: string | null;
-  customs?: ApiCustoms | null;
+  createdAt?: string;
+  customs?: ApiCustoms[] | null;
 };
 
 export type ApiContract = {
@@ -91,6 +97,7 @@ export type ApiReview = {
   id?: string;
   rating: number;
   comment?: string | null;
+  text?: string | null;
   orderId?: string;
   supplierCompanyId?: string;
   createdAt?: string;
@@ -103,11 +110,18 @@ export type ApiOrder = {
   totalCurrency?: string | null;
   createdAt?: string;
   buyerId?: string | null;
+  buyerCompanyId?: string | null;
   supplierId?: string | null;
+  supplierCompanyId?: string | null;
   escrow?: ApiEscrow | null;
   shipments?: ApiShipment[];
   contract?: ApiContract | null;
   review?: ApiReview | null;
+};
+
+export type SupplierReviewsPayload = {
+  reviews: ApiReview[];
+  avg: number;
 };
 
 async function request<T>(input: RequestInfo, init?: RequestInit) {
@@ -141,6 +155,10 @@ export const api = {
     return request<ApiQuote[]>(`${API_BASE}/quotes/rfq/${rfqId}`, {
       cache: "no-store",
     });
+  },
+
+  async listOrders(): Promise<ApiOrder[]> {
+    return request<ApiOrder[]>(`${API_BASE}/orders`, { cache: "no-store" });
   },
 
   async acceptQuote(quoteId: string) {
@@ -236,8 +254,8 @@ export const api = {
     });
   },
 
-  async listSupplierReviews(companyId: string) {
-    return request<ApiReview[]>(`${API_BASE}/suppliers/${companyId}/reviews`, {
+  async listSupplierReviews(companyId: string): Promise<SupplierReviewsPayload> {
+    return request<SupplierReviewsPayload>(`${API_BASE}/suppliers/${companyId}/reviews`, {
       cache: "no-store",
     });
   },


### PR DESCRIPTION
## Summary
- add a GET /orders endpoint that returns dashboard-friendly order summaries including escrow, shipments, contracts, and reviews and document it in Swagger
- update the web API client with a listOrders helper and richer types that match the expanded payload
- adjust admin, order, and supplier review pages to consume the new helper and customs/review data without type casts

## Testing
- pnpm --filter @tijaralink/web build

------
https://chatgpt.com/codex/tasks/task_e_68e1942a4aa8832db7622fdb4126d819