### PR TITLE
Update supplier review payload handling

### DIFF
--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,13 +1,6 @@
 import Link from "next/link";
 
-import {
-  api,
-  ApiOrder,
-  ApiQuote,
-  ApiRfq,
-  ApiShipment,
-  SupplierReviewsPayload,
-} from "@/lib/api";
+import { api, ApiOrder, ApiQuote, ApiRfq, ApiShipment } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
 
@@ -111,8 +104,8 @@ export default async function AdminDashboard() {
     const responses = await Promise.all(
       supplierIds.map(async (supplierId) => {
         try {
-          const payload: SupplierReviewsPayload = await api.listSupplierReviews(supplierId);
-          return { id: supplierId, avg: payload.avg, count: payload.reviews.length };
+          const { reviews, avg } = await api.listSupplierReviews(supplierId);
+          return { id: supplierId, avg, count: reviews.length };
         } catch (error) {
           console.error("Failed to load supplier reviews for", supplierId, error);
           return null;

--- a/apps/web/app/suppliers/[companyId]/reviews/page.tsx
+++ b/apps/web/app/suppliers/[companyId]/reviews/page.tsx
@@ -15,26 +15,21 @@ function formatDate(value?: string) {
   }).format(date);
 }
 
-function averageRating(reviews: ApiReview[]) {
-  if (!reviews.length) return 0;
-  const total = reviews.reduce((acc, review) => acc + (review.rating || 0), 0);
-  return total / reviews.length;
-}
-
 export default async function SupplierReviewsPage({ params }: { params: { companyId: string } }) {
   const { companyId } = params;
 
   let reviews: ApiReview[] = [];
+  let average = 0;
   let error: string | null = null;
 
   try {
-    reviews = await api.listSupplierReviews(companyId);
+    const { reviews: supplierReviews, avg } = await api.listSupplierReviews(companyId);
+    reviews = supplierReviews;
+    average = avg;
   } catch (err) {
     console.error("Failed to load supplier reviews", err);
     error = (err as Error)?.message || "Unable to load reviews";
   }
-
-  const average = averageRating(reviews);
 
   return (
     <main className="detail-page">
@@ -43,7 +38,8 @@ export default async function SupplierReviewsPage({ params }: { params: { compan
           <p className="eyebrow">Supplier performance</p>
           <h1>Reviews for {companyId}</h1>
           <p className="section-subtitle">
-            Average rating {average ? average.toFixed(2) : "–"} from {reviews.length} review{reviews.length === 1 ? "" : "s"}.
+            Average rating {reviews.length ? average.toFixed(2) : "–"} from {reviews.length} review
+            {reviews.length === 1 ? "" : "s"}.
           </p>
         </div>
         <Link className="button-secondary" href="/">

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -96,6 +96,11 @@ export type ApiReview = {
   createdAt?: string;
 };
 
+export type SupplierReviewsPayload = {
+  reviews: ApiReview[];
+  avg: number;
+};
+
 export type ApiOrder = {
   id: string;
   status?: string | null;
@@ -237,7 +242,7 @@ export const api = {
   },
 
   async listSupplierReviews(companyId: string) {
-    return request<ApiReview[]>(`${API_BASE}/suppliers/${companyId}/reviews`, {
+    return request<SupplierReviewsPayload>(`${API_BASE}/suppliers/${companyId}/reviews`, {
       cache: "no-store",
     });
   },


### PR DESCRIPTION
## Summary
- add a reusable SupplierReviewsPayload type and update listSupplierReviews to return it
- adjust admin dashboards to destructure review payload data instead of casting
- update the supplier reviews page to consume the payload shape for both average and list rendering

## Testing
- pnpm --filter @tijaralink/web build *(fails: api.listOrders is not defined in the API helper)*

------
https://chatgpt.com/codex/tasks/task_e_68e1942aee08832db8685eb57162318c