### PR TITLE
Align order detail data with nested shipments and review

### DIFF
--- a/apps/web/app/admin/orders/page.tsx
+++ b/apps/web/app/admin/orders/page.tsx
@@ -62,7 +62,7 @@ export default async function AdminOrdersPage() {
               </thead>
               <tbody>
                 {orders.map((order) => {
-                  const shipmentsCount = order.shipments?.length ?? 0;
+                  const shipmentsCount = order.shipments.length;
                   const contractState = order.contract
                     ? order.contract.buyerSignedAt && order.contract.supplierSignedAt
                       ? "Signed"

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -79,7 +79,7 @@ export default async function AdminDashboard() {
     orders = [];
   }
 
-  const shipments: ApiShipment[] = orders.flatMap((order) => order.shipments || []);
+  const shipments: ApiShipment[] = orders.flatMap((order) => order.shipments);
 
   const rfqStats = {
     open: rfqs.filter((rfq) => !/CLOSED/.test(toStatusKey(rfq.status))).length,
@@ -100,9 +100,7 @@ export default async function AdminDashboard() {
 
   const supplierIds = Array.from(
     new Set(
-      orders
-        .map((order) => order.supplierCompanyId || order.supplierId)
-        .filter((value): value is string => Boolean(value))
+      orders.map((order) => order.supplierId).filter((value): value is string => Boolean(value))
     )
   );
 

--- a/apps/web/app/admin/reviews/page.tsx
+++ b/apps/web/app/admin/reviews/page.tsx
@@ -28,9 +28,7 @@ export default async function AdminReviewsPage() {
 
   const supplierIds = Array.from(
     new Set(
-      orders
-        .map((order) => order.supplierCompanyId || order.supplierId)
-        .filter((value): value is string => Boolean(value))
+      orders.map((order) => order.supplierId).filter((value): value is string => Boolean(value))
     )
   );
 

--- a/apps/web/app/admin/shipments/page.tsx
+++ b/apps/web/app/admin/shipments/page.tsx
@@ -33,7 +33,7 @@ export default async function AdminShipmentsPage() {
     error = (err as Error)?.message || "Unable to load shipments";
   }
 
-  const shipments: ApiShipment[] = orders.flatMap((order) => order.shipments || []);
+  const shipments: ApiShipment[] = orders.flatMap((order) => order.shipments);
 
   return (
     <main className="detail-page">

--- a/apps/web/app/orders/[id]/page.tsx
+++ b/apps/web/app/orders/[id]/page.tsx
@@ -99,8 +99,8 @@ export default async function OrderPage({ params }: { params: { id: string } }) 
           <p className="eyebrow">Order #{order.id}</p>
           <h1>{formatCurrency(order.totalMinor, order.totalCurrency)}</h1>
           <p className="section-subtitle">
-            Status: {order.status || "Pending"} • Created {formatDate(order.createdAt)} • Buyer {order.buyerId || "—"} • Supplier {" "}
-            {order.supplierId || "—"}
+            Status: {order.status || "Pending"} • Created {formatDate(order.createdAt)} • Buyer {order.buyerId ?? "—"} • Supplier {" "}
+            {order.supplierId ?? "—"}
           </p>
         </div>
         <Link className="button-secondary" href="/rfq">
@@ -151,14 +151,14 @@ export default async function OrderPage({ params }: { params: { id: string } }) 
               Create consignments, attach customs, and keep status aligned with operations.
             </p>
           </div>
-          <span className="badge-inline">{order.shipments?.length || 0} records</span>
+          <span className="badge-inline">{order.shipments.length} records</span>
         </div>
 
         <CreateShipmentForm orderId={order.id} />
 
-        {(order.shipments || []).length ? (
+        {order.shipments.length ? (
           <ul className="list-stack">
-            {order.shipments?.map((shipment) => (
+            {order.shipments.map((shipment) => (
               <li key={shipment.id} className="shipment-card">
                 <div className="shipment-card__header">
                   <div>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -75,7 +75,7 @@ export type ApiShipment = {
   mode?: string | null;
   tracking?: string | null;
   status?: string | null;
-  customs?: ApiCustoms | null;
+  customs: ApiCustoms | null;
 };
 
 export type ApiContract = {
@@ -102,12 +102,12 @@ export type ApiOrder = {
   totalMinor?: number;
   totalCurrency?: string | null;
   createdAt?: string;
-  buyerId?: string | null;
-  supplierId?: string | null;
+  buyerId: string | null;
+  supplierId: string | null;
   escrow?: ApiEscrow | null;
-  shipments?: ApiShipment[];
+  shipments: ApiShipment[];
   contract?: ApiContract | null;
-  review?: ApiReview | null;
+  review: ApiReview | null;
 };
 
 async function request<T>(input: RequestInfo, init?: RequestInit) {


### PR DESCRIPTION
## Summary
- include customs and reviews in order detail responses while mapping buyer/supplier IDs and a single review field
- refresh frontend API types to always expose shipments, customs, and review data and rely on buyer/supplier IDs
- update order and admin pages to consume the canonical fields without undefined fallbacks

## Testing
- pnpm lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1942d3910832dbe6f65800bbda460