### PR TITLE
feat(web): add mock auth flows and dashboards

### DIFF
--- a/apps/web/app/buyer/dashboard/page.tsx
+++ b/apps/web/app/buyer/dashboard/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+import { useAuth } from "../../providers/AuthProvider";
+
+export default function BuyerDashboardPage() {
+  const router = useRouter();
+  const { session, isHydrated } = useAuth();
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    if (!session) {
+      router.replace("/login?role=buyer&redirect=/buyer/dashboard");
+      return;
+    }
+    if (session.role !== "buyer") {
+      router.replace("/seller/dashboard");
+    }
+  }, [isHydrated, router, session]);
+
+  if (!isHydrated || !session || session.role !== "buyer") {
+    return (
+      <main className="page">
+        <section className="card">
+          <h1>Redirecting…</h1>
+          <p>Checking your access and preparing your workspace.</p>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="page">
+      <section className="card hero">
+        <div className="hero__content">
+          <span className="hero__eyebrow">Buyer Workspace</span>
+          <h1 className="hero__title">Welcome back, {session.name ?? session.email}!</h1>
+          <p className="hero__subtitle">
+            Launch RFQs, review supplier responses, and keep procurement moving forward.
+          </p>
+          <div className="cta-row">
+            <Link className="button-primary" href="/#create-rfq">
+              Start a new RFQ
+            </Link>
+            <Link className="button-secondary" href="/orders">
+              Review open orders
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="layout-grid">
+        <div className="card card--compact">
+          <div className="hero__content" style={{ maxWidth: "100%", gap: "8px" }}>
+            <h2 className="hero__title" style={{ fontSize: "1.75rem" }}>Quick buyer links</h2>
+            <p className="hero__subtitle" style={{ fontSize: "1rem" }}>
+              Jump into your most common workflows in just a click.
+            </p>
+          </div>
+          <ul className="dashboard-list">
+            <li>
+              <Link href="/rfq" className="dashboard-link">
+                View all RFQs
+              </Link>
+            </li>
+            <li>
+              <Link href="/orders" className="dashboard-link">
+                Track purchase orders
+              </Link>
+            </li>
+            <li>
+              <Link href="/suppliers" className="dashboard-link">
+                Browse verified suppliers
+              </Link>
+            </li>
+          </ul>
+        </div>
+
+        <aside className="card card--compact">
+          <h3 style={{ marginTop: 0 }}>Latest updates</h3>
+          <p style={{ color: "var(--muted)", marginBottom: "12px" }}>
+            This is a mock dashboard. Connect the API to surface live RFQ status summaries.
+          </p>
+          <ul className="dashboard-updates">
+            <li>✔️ Supplier profiles refreshed hourly.</li>
+            <li>📬 Escrow workflows support digital signatures.</li>
+            <li>⚡ Import RFQs directly from spreadsheets.</li>
+          </ul>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/components/HeroCtaButtons.tsx
+++ b/apps/web/app/components/HeroCtaButtons.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { useAuth } from "../providers/AuthProvider";
+
+export default function HeroCtaButtons() {
+  const { session, isHydrated } = useAuth();
+
+  if (!isHydrated) {
+    return (
+      <>
+        <Link className="button-primary" href="/login">
+          Log in
+        </Link>
+        <Link className="button-secondary" href="/register">
+          Create account
+        </Link>
+      </>
+    );
+  }
+
+  if (session) {
+    const dashboardHref = session.role === "seller" ? "/seller/dashboard" : "/buyer/dashboard";
+    return (
+      <>
+        <Link className="button-primary" href={dashboardHref}>
+          View Dashboard
+        </Link>
+        <a className="button-secondary" href="#create-rfq">
+          Start a New RFQ
+        </a>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Link className="button-primary" href="/login">
+        Log in
+      </Link>
+      <Link className="button-secondary" href="/register">
+        Create account
+      </Link>
+    </>
+  );
+}

--- a/apps/web/app/components/SiteHeader.tsx
+++ b/apps/web/app/components/SiteHeader.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useAuth } from "../providers/AuthProvider";
+
+function navLinkClassName(isActive: boolean) {
+  return isActive ? "site-header__link site-header__link--active" : "site-header__link";
+}
+
+export default function SiteHeader() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { session, logout, isHydrated } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    router.push("/");
+  };
+
+  const dashboardHref = session?.role === "seller" ? "/seller/dashboard" : "/buyer/dashboard";
+
+  return (
+    <header className="site-header">
+      <div className="site-header__inner">
+        <Link href="/" className="site-header__brand">
+          TijaraLink
+        </Link>
+        <nav className="site-header__nav" aria-label="Primary">
+          <Link href="/" className={navLinkClassName(pathname === "/")}>Home</Link>
+          <Link href="/rfq" className={navLinkClassName(pathname?.startsWith("/rfq") ?? false)}>
+            RFQs
+          </Link>
+          <Link
+            href="/suppliers"
+            className={navLinkClassName(pathname?.startsWith("/suppliers") ?? false)}
+          >
+            Suppliers
+          </Link>
+          <Link href="/orders" className={navLinkClassName(pathname?.startsWith("/orders") ?? false)}>
+            Orders
+          </Link>
+        </nav>
+        <div className="site-header__actions">
+          {isHydrated && session ? (
+            <>
+              <span className="site-header__welcome">Welcome, {session.name ?? session.email}</span>
+              <Link href={dashboardHref} className="button-primary">
+                View Dashboard
+              </Link>
+              <button type="button" className="button-secondary" onClick={handleLogout}>
+                Logout
+              </button>
+            </>
+          ) : (
+            <>
+              <Link href="/login" className="button-secondary">
+                Log in
+              </Link>
+              <Link href="/register" className="button-primary">
+                Create account
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -41,6 +41,66 @@ body::before {
   z-index: -1;
 }
 
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(14px);
+  background: rgba(255, 255, 255, 0.86);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.site-header__inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 18px 24px;
+  display: flex;
+  align-items: center;
+  gap: 32px;
+}
+
+.site-header__brand {
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: 0.02em;
+  color: var(--foreground);
+  text-decoration: none;
+}
+
+.site-header__nav {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex: 1;
+}
+
+.site-header__link {
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 150ms ease;
+}
+
+.site-header__link:hover,
+.site-header__link:focus-visible {
+  color: var(--foreground);
+}
+
+.site-header__link--active {
+  color: var(--foreground);
+}
+
+.site-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.site-header__welcome {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
 main.page {
   max-width: 1200px;
   margin: 0 auto;
@@ -166,10 +226,157 @@ main.page {
   font-size: 15px;
   text-decoration: none;
   transition: background 150ms ease;
+  cursor: pointer;
 }
 
 .button-secondary:hover {
   background: rgba(148, 163, 184, 0.12);
+}
+
+main.auth-page {
+  max-width: 520px;
+  padding: 80px 24px 120px;
+}
+
+.auth-card {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.auth-card__header {
+  display: grid;
+  gap: 8px;
+}
+
+.auth-card__title {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.auth-card__subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.auth-form {
+  display: grid;
+  gap: 18px;
+}
+
+.auth-form__group {
+  display: grid;
+  gap: 8px;
+}
+
+.auth-form__label {
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.auth-form__input,
+.auth-form__select {
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 12px 14px;
+  font-size: 1rem;
+  background: white;
+  font-family: inherit;
+}
+
+.auth-form__remember {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.auth-role-selector {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.auth-role-option {
+  flex: 1 1 140px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: var(--radius-sm);
+  padding: 14px 16px;
+  display: grid;
+  gap: 6px;
+  cursor: pointer;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.auth-role-option input {
+  display: none;
+}
+
+.auth-role-option span {
+  font-weight: 600;
+}
+
+.auth-role-option small {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.auth-role-option--active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.auth-divider {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.auth-error {
+  margin: 0;
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.dashboard-list {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
+  display: grid;
+  gap: 12px;
+}
+
+.dashboard-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--foreground);
+  transition: color 150ms ease;
+}
+
+.dashboard-link::before {
+  content: "→";
+  font-size: 0.95rem;
+  opacity: 0.6;
+}
+
+.dashboard-link:hover,
+.dashboard-link:focus-visible {
+  color: var(--accent);
+}
+
+.dashboard-updates {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: grid;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 0.95rem;
 }
 
 .stats-grid {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Poppins } from "next/font/google";
 
 import "./globals.css";
+import AuthProvider from "./providers/AuthProvider";
+import SiteHeader from "./components/SiteHeader";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -18,7 +20,12 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" dir="ltr">
-      <body className={poppins.className}>{children}</body>
+      <body className={poppins.className}>
+        <AuthProvider>
+          <SiteHeader />
+          {children}
+        </AuthProvider>
+      </body>
     </html>
   );
 }

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+import { useAuth, type UserRole } from "../providers/AuthProvider";
+
+const ROLE_OPTIONS: Array<{ value: UserRole; title: string; description: string; emoji: string }> = [
+  {
+    value: "buyer",
+    title: "Buyer",
+    description: "Procurement teams managing sourcing and RFQs.",
+    emoji: "🛒",
+  },
+  {
+    value: "seller",
+    title: "Seller",
+    description: "Suppliers responding to new opportunities.",
+    emoji: "🏭",
+  },
+];
+
+export default function LoginPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { session, login, isHydrated } = useAuth();
+
+  const [role, setRole] = useState<UserRole>("buyer");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [remember, setRemember] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const roleParam = searchParams.get("role");
+    if (roleParam === "buyer" || roleParam === "seller") {
+      setRole(roleParam);
+    }
+  }, [searchParams]);
+
+  const destination = useMemo(() => {
+    const redirect = searchParams.get("redirect");
+    if (redirect) return redirect;
+    return role === "seller" ? "/seller/dashboard" : "/buyer/dashboard";
+  }, [role, searchParams]);
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    if (session) {
+      const dashboard = session.role === "seller" ? "/seller/dashboard" : "/buyer/dashboard";
+      router.replace(dashboard);
+    }
+  }, [isHydrated, router, session]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!email.trim()) {
+      setError("Please enter your email address.");
+      return;
+    }
+    if (!password) {
+      setError("Please enter your password.");
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+    login({ role, email, remember });
+    router.push(destination);
+  };
+
+  return (
+    <main className="page auth-page">
+      <section className="card auth-card">
+        <div className="auth-card__header">
+          <h1 className="auth-card__title">Welcome back</h1>
+          <p className="auth-card__subtitle">Select your role and sign in to continue collaborating.</p>
+        </div>
+
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <div className="auth-form__group">
+            <span className="auth-form__label">Choose your role</span>
+            <div className="auth-role-selector">
+              {ROLE_OPTIONS.map((option) => {
+                const isActive = role === option.value;
+                return (
+                  <label
+                    key={option.value}
+                    className={`auth-role-option${isActive ? " auth-role-option--active" : ""}`}
+                  >
+                    <input
+                      type="radio"
+                      name="role"
+                      value={option.value}
+                      checked={isActive}
+                      onChange={() => setRole(option.value)}
+                    />
+                    <span>
+                      {option.emoji} {option.title}
+                    </span>
+                    <small>{option.description}</small>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="auth-form__group">
+            <label className="auth-form__label" htmlFor="email">
+              Email address
+            </label>
+            <input
+              id="email"
+              type="email"
+              className="auth-form__input"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="you@example.com"
+              required
+            />
+          </div>
+
+          <div className="auth-form__group">
+            <label className="auth-form__label" htmlFor="password">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              className="auth-form__input"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              placeholder="••••••••"
+              required
+            />
+          </div>
+
+          <label className="auth-form__remember">
+            <input
+              type="checkbox"
+              checked={remember}
+              onChange={(event) => setRemember(event.target.checked)}
+            />
+            Keep me signed in on this device
+          </label>
+
+          {error ? <p className="auth-error">{error}</p> : null}
+
+          <button type="submit" className="button-primary" disabled={isSubmitting}>
+            {isSubmitting ? "Signing in..." : "Sign in"}
+          </button>
+        </form>
+
+        <p className="auth-divider">
+          Need an account? <Link href="/register">Create one in moments.</Link>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,7 @@
 // apps/web/app/page.tsx
 import { api, API_BASE, type ApiRfq } from "@/lib/api";
 import NewRfqForm from "./components/NewRfqForm";
+import HeroCtaButtons from "./components/HeroCtaButtons";
 
 export const dynamic = "force-dynamic";
 
@@ -47,7 +48,7 @@ export default async function Home() {
             Monitor every request-for-quote, engage trusted partners, and move from sourcing to awarding with total confidence.
           </p>
           <div className="cta-row">
-            <a className="button-primary" href="#create-rfq">Start a New RFQ</a>
+            <HeroCtaButtons />
             <a className="button-secondary" href={`${API_BASE}/health`} target="_blank" rel="noreferrer">
               API Health Endpoint
             </a>

--- a/apps/web/app/providers/AuthProvider.tsx
+++ b/apps/web/app/providers/AuthProvider.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+export type UserRole = "buyer" | "seller";
+
+type AuthSession = {
+  role: UserRole;
+  email: string;
+  name?: string;
+  createdAt: string;
+};
+
+type LoginPayload = {
+  role: UserRole;
+  email: string;
+  name?: string;
+  remember?: boolean;
+};
+
+type AuthContextValue = {
+  session: AuthSession | null;
+  login: (payload: LoginPayload) => void;
+  logout: () => void;
+  isHydrated: boolean;
+};
+
+const SESSION_STORAGE_KEY = "tijara-link.session";
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+function readStoredSession(): AuthSession | null {
+  if (typeof window === "undefined") return null;
+
+  const localValue = window.localStorage.getItem(SESSION_STORAGE_KEY);
+  const sessionValue = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+  const raw = localValue ?? sessionValue;
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as AuthSession;
+    if (!parsed?.role || !parsed?.email) return null;
+    return parsed;
+  } catch (error) {
+    console.warn("Unable to parse stored session", error);
+    return null;
+  }
+}
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<AuthSession | null>(null);
+  const [isHydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    const stored = readStoredSession();
+    if (stored) {
+      setSession(stored);
+    }
+    setHydrated(true);
+  }, []);
+
+  const login = useCallback((payload: LoginPayload) => {
+    if (typeof window === "undefined") return;
+
+    const { role, email, name, remember } = payload;
+    const normalizedName = name?.trim() || email.split("@")[0] || "User";
+    const nextSession: AuthSession = {
+      role,
+      email,
+      name: normalizedName,
+      createdAt: new Date().toISOString(),
+    };
+
+    const preferredStorage = remember ? window.localStorage : window.sessionStorage;
+    const secondaryStorage = remember ? window.sessionStorage : window.localStorage;
+
+    preferredStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(nextSession));
+    secondaryStorage.removeItem(SESSION_STORAGE_KEY);
+
+    setSession(nextSession);
+  }, []);
+
+  const logout = useCallback(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(SESSION_STORAGE_KEY);
+      window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+    }
+    setSession(null);
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      session,
+      login,
+      logout,
+      isHydrated,
+    }),
+    [isHydrated, login, logout, session],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+}

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+import { useAuth, type UserRole } from "../providers/AuthProvider";
+
+const ROLE_OPTIONS: Array<{ value: UserRole; title: string; description: string; emoji: string }> = [
+  {
+    value: "buyer",
+    title: "Buyer",
+    description: "Create RFQs and manage sourcing teams.",
+    emoji: "🤝",
+  },
+  {
+    value: "seller",
+    title: "Seller",
+    description: "Respond to leads and close new deals.",
+    emoji: "🚚",
+  },
+];
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { session, login, isHydrated } = useAuth();
+
+  const [role, setRole] = useState<UserRole>("buyer");
+  const [fullName, setFullName] = useState("");
+  const [company, setCompany] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [remember, setRemember] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const roleParam = searchParams.get("role");
+    if (roleParam === "buyer" || roleParam === "seller") {
+      setRole(roleParam);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    if (session) {
+      const destination = session.role === "seller" ? "/seller/dashboard" : "/buyer/dashboard";
+      router.replace(destination);
+    }
+  }, [isHydrated, router, session]);
+
+  const destination = useMemo(
+    () => (role === "seller" ? "/seller/dashboard" : "/buyer/dashboard"),
+    [role],
+  );
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!fullName.trim()) {
+      setError("Please provide your name.");
+      return;
+    }
+
+    if (!company.trim()) {
+      setError("Share your company or team name to continue.");
+      return;
+    }
+
+    if (!email.trim()) {
+      setError("Please provide a valid email address.");
+      return;
+    }
+
+    if (!password) {
+      setError("Create a password to secure your account.");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match. Double-check and try again.");
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    login({ role, email, name: fullName, remember });
+    router.push(destination);
+  };
+
+  return (
+    <main className="page auth-page">
+      <section className="card auth-card">
+        <div className="auth-card__header">
+          <h1 className="auth-card__title">Create your TijaraLink account</h1>
+          <p className="auth-card__subtitle">
+            Choose how you&apos;ll collaborate on TijaraLink and finish onboarding in under a minute.
+          </p>
+        </div>
+
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <div className="auth-form__group">
+            <span className="auth-form__label">Sign up as</span>
+            <div className="auth-role-selector">
+              {ROLE_OPTIONS.map((option) => {
+                const isActive = role === option.value;
+                return (
+                  <label
+                    key={option.value}
+                    className={`auth-role-option${isActive ? " auth-role-option--active" : ""}`}
+                  >
+                    <input
+                      type="radio"
+                      name="role"
+                      value={option.value}
+                      checked={isActive}
+                      onChange={() => setRole(option.value)}
+                    />
+                    <span>
+                      {option.emoji} {option.title}
+                    </span>
+                    <small>{option.description}</small>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="auth-form__group">
+            <label className="auth-form__label" htmlFor="fullName">
+              Full name
+            </label>
+            <input
+              id="fullName"
+              type="text"
+              className="auth-form__input"
+              value={fullName}
+              onChange={(event) => setFullName(event.target.value)}
+              placeholder="Amira Khan"
+              required
+            />
+          </div>
+
+          <div className="auth-form__group">
+            <label className="auth-form__label" htmlFor="company">
+              Company or team
+            </label>
+            <input
+              id="company"
+              type="text"
+              className="auth-form__input"
+              value={company}
+              onChange={(event) => setCompany(event.target.value)}
+              placeholder="Tijara Group"
+              required
+            />
+          </div>
+
+          <div className="auth-form__group">
+            <label className="auth-form__label" htmlFor="email">
+              Work email
+            </label>
+            <input
+              id="email"
+              type="email"
+              className="auth-form__input"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="amira@company.com"
+              required
+            />
+          </div>
+
+          <div className="auth-form__group">
+            <label className="auth-form__label" htmlFor="password">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              className="auth-form__input"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              placeholder="Create a secure password"
+              required
+            />
+          </div>
+
+          <div className="auth-form__group">
+            <label className="auth-form__label" htmlFor="confirmPassword">
+              Confirm password
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              className="auth-form__input"
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              placeholder="Re-enter your password"
+              required
+            />
+          </div>
+
+          <label className="auth-form__remember">
+            <input
+              type="checkbox"
+              checked={remember}
+              onChange={(event) => setRemember(event.target.checked)}
+            />
+            Keep me signed in on this device
+          </label>
+
+          {error ? <p className="auth-error">{error}</p> : null}
+
+          <button type="submit" className="button-primary" disabled={isSubmitting}>
+            {isSubmitting ? "Creating account..." : "Create account"}
+          </button>
+        </form>
+
+        <p className="auth-divider">
+          Already using TijaraLink? <Link href="/login">Sign in here.</Link>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/seller/dashboard/page.tsx
+++ b/apps/web/app/seller/dashboard/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+import { useAuth } from "../../providers/AuthProvider";
+
+export default function SellerDashboardPage() {
+  const router = useRouter();
+  const { session, isHydrated } = useAuth();
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    if (!session) {
+      router.replace("/login?role=seller&redirect=/seller/dashboard");
+      return;
+    }
+    if (session.role !== "seller") {
+      router.replace("/buyer/dashboard");
+    }
+  }, [isHydrated, router, session]);
+
+  if (!isHydrated || !session || session.role !== "seller") {
+    return (
+      <main className="page">
+        <section className="card">
+          <h1>Redirecting…</h1>
+          <p>Checking your access and preparing supplier insights.</p>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="page">
+      <section className="card hero">
+        <div className="hero__content">
+          <span className="hero__eyebrow">Seller Workspace</span>
+          <h1 className="hero__title">Great to see you, {session.name ?? session.email}!</h1>
+          <p className="hero__subtitle">
+            Respond to RFQs, manage contracts, and stay ahead of buyer expectations.
+          </p>
+          <div className="cta-row">
+            <Link className="button-primary" href="/rfq">
+              Discover active RFQs
+            </Link>
+            <Link className="button-secondary" href="/suppliers">
+              Update your profile
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="layout-grid">
+        <div className="card card--compact">
+          <div className="hero__content" style={{ maxWidth: "100%", gap: "8px" }}>
+            <h2 className="hero__title" style={{ fontSize: "1.75rem" }}>Quick seller actions</h2>
+            <p className="hero__subtitle" style={{ fontSize: "1rem" }}>
+              Stay responsive and highlight what sets your team apart.
+            </p>
+          </div>
+          <ul className="dashboard-list">
+            <li>
+              <Link href="/rfq" className="dashboard-link">
+                Browse open opportunities
+              </Link>
+            </li>
+            <li>
+              <Link href="/orders" className="dashboard-link">
+                Manage escrow-backed orders
+              </Link>
+            </li>
+            <li>
+              <Link href="/suppliers" className="dashboard-link">
+                Share testimonials and reviews
+              </Link>
+            </li>
+          </ul>
+        </div>
+
+        <aside className="card card--compact">
+          <h3 style={{ marginTop: 0 }}>Marketplace tips</h3>
+          <p style={{ color: "var(--muted)", marginBottom: "12px" }}>
+            Boost your win rate with actionable insights from successful suppliers.
+          </p>
+          <ul className="dashboard-updates">
+            <li>💬 Reply to RFQs within 24 hours to stay top-of-mind.</li>
+            <li>📈 Keep catalogs updated to showcase inventory strength.</li>
+            <li>🤝 Highlight certifications to build trust quickly.</li>
+          </ul>
+        </aside>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a client-side auth provider with navigation updates to reflect mock session state
- add login and registration flows with role-based redirects and local/session storage persistence
- introduce buyer and seller dashboards plus CTA updates and supporting styling tweaks

## Testing
- pnpm --filter @tijaralink/web build *(fails: existing duplicate `average` variable in apps/web/app/suppliers/[companyId]/reviews/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f296a7fc832d87fa98cddcd440f3