### PR TITLE
feat(web): add seller workspace

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -369,6 +369,129 @@ main.page {
   font-size: 13px;
 }
 
+.form-error {
+  color: #be123c;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.form-success {
+  color: #047857;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.seller-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 260px) 1fr;
+  min-height: 100vh;
+}
+
+.seller-sidebar {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 48px 32px;
+  border-right: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.76);
+  backdrop-filter: blur(16px);
+}
+
+.seller-profile {
+  display: grid;
+  gap: 6px;
+}
+
+.seller-profile__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.16);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.seller-profile__name {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.seller-profile__meta {
+  font-size: 0.95rem;
+  color: var(--foreground);
+}
+
+.seller-profile__meta--muted {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.seller-nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.seller-nav__link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  color: var(--foreground);
+  text-decoration: none;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.seller-nav__link:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.seller-nav__link--active {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: white;
+  box-shadow: var(--shadow-md);
+}
+
+.seller-content {
+  padding: 48px 40px;
+}
+
+.review-scorecard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: white;
+  box-shadow: var(--shadow-md);
+}
+
+.review-scorecard__value {
+  font-size: clamp(2.5rem, 4vw, 3rem);
+  font-weight: 700;
+  color: var(--accent-strong);
+}
+
+.review-scorecard__meta {
+  margin-top: 8px;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
 a.link-muted {
   color: var(--accent);
   text-decoration: none;
@@ -392,5 +515,21 @@ a.link-muted:hover {
 
   .form__footer {
     align-items: flex-start;
+  }
+}
+
+@media (max-width: 960px) {
+  .seller-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .seller-sidebar {
+    position: static;
+    border-right: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  }
+
+  .seller-content {
+    padding: 32px 24px;
   }
 }

--- a/apps/web/app/seller/components/QuoteSubmissionForm.tsx
+++ b/apps/web/app/seller/components/QuoteSubmissionForm.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { api } from "@/lib/api";
+
+type RfqOption = {
+  id: string;
+  title: string;
+  destinationCountry?: string | null;
+};
+
+type Props = {
+  rfqs: RfqOption[];
+};
+
+type FormStatus = {
+  error: string | null;
+  success: string | null;
+};
+
+export default function QuoteSubmissionForm({ rfqs }: Props) {
+  const router = useRouter();
+  const [status, setStatus] = useState<FormStatus>({ error: null, success: null });
+  const [isPending, startTransition] = useTransition();
+  const [selectedRfq, setSelectedRfq] = useState<string>(rfqs[0]?.id ?? "");
+
+  const rfqOptions = useMemo(() => rfqs.map((rfq) => ({
+    value: rfq.id,
+    label: `${rfq.title}${rfq.destinationCountry ? ` → ${rfq.destinationCountry}` : ""}`,
+  })), [rfqs]);
+
+  const hasRfqs = rfqOptions.length > 0;
+
+  useEffect(() => {
+    setSelectedRfq(rfqs[0]?.id ?? "");
+  }, [rfqs]);
+
+  return (
+    <form
+      className="form"
+      onSubmit={(event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!hasRfqs || isPending) return;
+
+        const formData = new FormData(event.currentTarget);
+        startTransition(async () => {
+          const rfqId = (formData.get("rfqId") || "").toString();
+          const currency = (formData.get("currency") || "USD").toString().toUpperCase();
+          const pricePerUnitMinor = Number(formData.get("pricePerUnitMinor") || 0);
+          const moqRaw = formData.get("moq");
+          const leadTimeRaw = formData.get("leadTimeDays");
+
+          setStatus({ error: null, success: null });
+
+          if (!rfqId) {
+            setStatus({ error: "Select an RFQ before submitting a quote.", success: null });
+            return;
+          }
+
+          if (!Number.isFinite(pricePerUnitMinor) || pricePerUnitMinor <= 0) {
+            setStatus({ error: "Enter a valid unit price in minor units.", success: null });
+            return;
+          }
+
+          try {
+            await api.createQuote({
+              rfqId,
+              currency,
+              pricePerUnitMinor,
+              moq: moqRaw ? Number(moqRaw) : undefined,
+              leadTimeDays: leadTimeRaw ? Number(leadTimeRaw) : undefined,
+            });
+            setStatus({ error: null, success: "Quote submitted successfully." });
+            event.currentTarget.reset();
+            setSelectedRfq(rfqOptions[0]?.value ?? "");
+            router.refresh();
+          } catch (error) {
+            console.error(error);
+            setStatus({
+              error: (error as Error)?.message || "Failed to submit quote.",
+              success: null,
+            });
+          }
+        });
+      }}
+    >
+      <div className="form__field">
+        <label className="form__label" htmlFor="rfqId">
+          RFQ
+        </label>
+        <select
+          id="rfqId"
+          name="rfqId"
+          className="select"
+          value={selectedRfq}
+          onChange={(event) => setSelectedRfq(event.target.value)}
+          disabled={!hasRfqs || isPending}
+          required
+        >
+          {hasRfqs ? (
+            rfqOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))
+          ) : (
+            <option value="">No open RFQs</option>
+          )}
+        </select>
+      </div>
+
+      <div className="form__field-group">
+        <div className="form__field">
+          <label className="form__label" htmlFor="currency">
+            Currency
+          </label>
+          <input
+            id="currency"
+            name="currency"
+            className="input"
+            defaultValue="USD"
+            placeholder="USD"
+            maxLength={3}
+            disabled={!hasRfqs || isPending}
+          />
+        </div>
+        <div className="form__field">
+          <label className="form__label" htmlFor="pricePerUnitMinor">
+            Price per unit (minor)
+          </label>
+          <input
+            id="pricePerUnitMinor"
+            name="pricePerUnitMinor"
+            type="number"
+            min={1}
+            step={1}
+            className="input"
+            placeholder="95000"
+            disabled={!hasRfqs || isPending}
+            required
+          />
+        </div>
+      </div>
+
+      <div className="form__field-group">
+        <div className="form__field">
+          <label className="form__label" htmlFor="moq">
+            Minimum order quantity
+          </label>
+          <input
+            id="moq"
+            name="moq"
+            type="number"
+            min={1}
+            step={1}
+            className="input"
+            placeholder="5"
+            disabled={!hasRfqs || isPending}
+          />
+        </div>
+        <div className="form__field">
+          <label className="form__label" htmlFor="leadTimeDays">
+            Lead time (days)
+          </label>
+          <input
+            id="leadTimeDays"
+            name="leadTimeDays"
+            type="number"
+            min={0}
+            step={1}
+            className="input"
+            placeholder="10"
+            disabled={!hasRfqs || isPending}
+          />
+        </div>
+      </div>
+
+      <div className="form__footer">
+        <button className="button-primary" type="submit" disabled={!hasRfqs || isPending}>
+          {isPending ? "Submitting..." : "Submit quote"}
+        </button>
+        <span className="form__hint">All amounts should use the API minor-unit format.</span>
+      </div>
+
+      {status.error && <p className="form-error">{status.error}</p>}
+      {status.success && <p className="form-success">{status.success}</p>}
+    </form>
+  );
+}

--- a/apps/web/app/seller/contracts/page.tsx
+++ b/apps/web/app/seller/contracts/page.tsx
@@ -1,0 +1,146 @@
+import Link from "next/link";
+
+import SignContractButton from "@/app/components/SignContractButton";
+import { api, ApiOrder } from "@/lib/api";
+
+import { mockSellerSession } from "../layout";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+export default async function SellerContractsPage() {
+  const session = mockSellerSession;
+
+  let orders: ApiOrder[] = [];
+  let error: string | null = null;
+
+  try {
+    orders = await api.listOrders();
+  } catch (err) {
+    console.error("Failed to load orders for seller contracts", err);
+    error = (err as Error)?.message || "Unable to load contracts";
+  }
+
+  const relevantOrders = orders.filter((order) => order.supplierCompanyId === session.companyId && order.contract);
+  const pendingContracts = relevantOrders.filter((order) => !order.contract?.supplierSignedAt);
+  const completedContracts = relevantOrders.filter((order) => order.contract?.supplierSignedAt);
+
+  return (
+    <main className="detail-page">
+      <header className="detail-header">
+        <div>
+          <p className="eyebrow">Fulfilment</p>
+          <h1>Contracts awaiting signature</h1>
+          <p className="section-subtitle">Review finalized purchase terms and execute supplier signatures.</p>
+        </div>
+        <Link className="button-secondary" href="/seller/dashboard">
+          ← Back to dashboard
+        </Link>
+      </header>
+
+      {error && <div className="alert alert--error">{error}</div>}
+
+      <section className="card card--compact">
+        <div className="section-heading">
+          <div>
+            <h2>Pending contracts</h2>
+            <p className="section-subtitle">Contracts ready for your signature to progress fulfilment.</p>
+          </div>
+          <span className="badge-inline">{pendingContracts.length}</span>
+        </div>
+
+        {pendingContracts.length ? (
+          <div className="table-wrapper">
+            <table className="rfq-table">
+              <thead>
+                <tr>
+                  <th>Order</th>
+                  <th>Terms</th>
+                  <th>Buyer signed</th>
+                  <th>Created</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pendingContracts.map((order) => (
+                  <tr key={order.id}>
+                    <td className="mono">
+                      <Link className="link-muted" href={`/orders/${order.id}`}>
+                        {order.id}
+                      </Link>
+                    </td>
+                    <td>{order.contract?.terms?.slice(0, 80) || "—"}</td>
+                    <td>{order.contract?.buyerSignedAt ? formatDate(order.contract?.buyerSignedAt) : "Awaiting"}</td>
+                    <td>{formatDate(order.contract?.createdAt)}</td>
+                    <td>
+                      {order.contract && <SignContractButton contractId={order.contract.id} role="supplier" />}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="empty-state">
+            <h3>Nothing to sign right now</h3>
+            <p>Once buyers countersign, their contracts will appear here for supplier execution.</p>
+          </div>
+        )}
+      </section>
+
+      <section className="card">
+        <div className="section-heading">
+          <div>
+            <h2>Completed contracts</h2>
+            <p className="section-subtitle">Archive of agreements you have already signed.</p>
+          </div>
+          <span className="badge-inline">{completedContracts.length}</span>
+        </div>
+
+        {completedContracts.length ? (
+          <div className="table-wrapper">
+            <table className="rfq-table">
+              <thead>
+                <tr>
+                  <th>Order</th>
+                  <th>Signed</th>
+                  <th>Buyer signature</th>
+                  <th>Terms</th>
+                </tr>
+              </thead>
+              <tbody>
+                {completedContracts.map((order) => (
+                  <tr key={`${order.id}-completed`}>
+                    <td className="mono">
+                      <Link className="link-muted" href={`/orders/${order.id}`}>
+                        {order.id}
+                      </Link>
+                    </td>
+                    <td>{formatDate(order.contract?.supplierSignedAt)}</td>
+                    <td>{formatDate(order.contract?.buyerSignedAt)}</td>
+                    <td>{order.contract?.terms?.slice(0, 80) || "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="empty-state">
+            <h3>No signed contracts yet</h3>
+            <p>As soon as you sign an agreement it will move into this archive for easy reference.</p>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/seller/dashboard/page.tsx
+++ b/apps/web/app/seller/dashboard/page.tsx
@@ -1,0 +1,145 @@
+import Link from "next/link";
+
+import QuoteSubmissionForm from "../components/QuoteSubmissionForm";
+import { mockSellerSession } from "../layout";
+import { api, ApiRfq } from "@/lib/api";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+function normalizeStatus(value?: string | null) {
+  return String(value || "").toUpperCase();
+}
+
+function statusClassName(status?: string | null) {
+  const normalized = normalizeStatus(status);
+  if (/(APPROVED|ACCEPTED|ACTIVE|AWARDED)/.test(normalized)) return "status-pill status-pill--approved";
+  if (/(CLOSED|CANCELLED|CANCELED|REJECTED|EXPIRED)/.test(normalized)) return "status-pill status-pill--closed";
+  if (/DRAFT/.test(normalized)) return "status-pill status-pill--draft";
+  return "status-pill status-pill--pending";
+}
+
+function isOpenRfq(rfq: ApiRfq) {
+  const status = normalizeStatus(rfq.status);
+  return !/(CLOSED|CANCELLED|CANCELED|EXPIRED)/.test(status);
+}
+
+export default async function SellerDashboardPage() {
+  const session = mockSellerSession;
+
+  let rfqs: ApiRfq[] = [];
+  let rfqError: string | null = null;
+
+  try {
+    rfqs = await api.listRfq();
+  } catch (error) {
+    console.error("Failed to load RFQs for seller dashboard", error);
+    rfqError = (error as Error)?.message || "Unable to load RFQs";
+  }
+
+  const openRfqs = rfqs.filter(isOpenRfq);
+
+  return (
+    <main className="detail-page">
+      <header className="detail-header">
+        <div>
+          <p className="eyebrow">Supplier workspace</p>
+          <h1>Seller dashboard</h1>
+          <p className="section-subtitle">Respond to buyer demand, track open RFQs, and maintain fulfilment readiness.</p>
+        </div>
+        <div className="cta-row" style={{ justifyContent: "flex-end" }}>
+          <Link className="button-secondary" href="/seller/contracts">
+            Contracts
+          </Link>
+          <Link className="button-secondary" href="/seller/reviews">
+            Reviews
+          </Link>
+        </div>
+      </header>
+
+      <section className="stats-grid">
+        <div className="stat-card">
+          <div className="stat-card__label">Open RFQs</div>
+          <div className="stat-card__value">{openRfqs.length}</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-card__label">Total RFQs</div>
+          <div className="stat-card__value">{rfqs.length}</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-card__label">Your company</div>
+          <div className="stat-card__value" style={{ fontSize: "1rem" }}>
+            {session.companyName}
+          </div>
+        </div>
+      </section>
+
+      {rfqError && <div className="alert alert--error">{rfqError}</div>}
+
+      <section className="layout-grid">
+        <div className="card card--compact">
+          <div className="section-heading">
+            <div>
+              <h2>Market opportunities</h2>
+              <p className="section-subtitle">Review buyer requirements and choose where to submit a proposal.</p>
+            </div>
+            <span className="badge-inline">{openRfqs.length} open</span>
+          </div>
+
+          {openRfqs.length ? (
+            <div className="table-wrapper">
+              <table className="rfq-table">
+                <thead>
+                  <tr>
+                    <th>Title</th>
+                    <th>Status</th>
+                    <th>Destination</th>
+                    <th>Created</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {openRfqs.map((rfq) => (
+                    <tr key={rfq.id}>
+                      <td>{rfq.title}</td>
+                      <td>
+                        <span className={statusClassName(rfq.status)}>{rfq.status || "Pending"}</span>
+                      </td>
+                      <td>{rfq.destinationCountry || "—"}</td>
+                      <td>{formatDate(rfq.createdAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="empty-state">
+              <h3>No open RFQs</h3>
+              <p>Buyers will publish new opportunities here once they are ready for supplier quotes.</p>
+            </div>
+          )}
+        </div>
+
+        <aside className="card card--compact">
+          <div className="form-card__title">Submit a quote</div>
+          <p className="form-card__subtitle">
+            Choose an RFQ and enter your pricing, minimum order quantity, and lead time to respond instantly.
+          </p>
+          <QuoteSubmissionForm rfqs={openRfqs} />
+          <p className="footer-note" style={{ marginTop: "24px" }}>
+            Need to check existing quotes? Visit the buyer RFQ detail view after submitting to monitor status.
+          </p>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/seller/layout.tsx
+++ b/apps/web/app/seller/layout.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+
+import { SellerNavigation } from "./navigation";
+
+export type SellerSession = {
+  id: string;
+  companyId: string;
+  companyName: string;
+  contactName: string;
+  email: string;
+  role: "supplier";
+};
+
+export const mockSellerSession: SellerSession = {
+  id: "seller-user-001",
+  companyId: "demo-supplier-tr",
+  companyName: "Demo Supplier TR",
+  contactName: "Amal Yılmaz",
+  email: "amal@demosuppliertr.com",
+  role: "supplier",
+};
+
+const navigationItems = [
+  { href: "/seller/dashboard", label: "Dashboard" },
+  { href: "/seller/contracts", label: "Contracts" },
+  { href: "/seller/reviews", label: "Reviews" },
+];
+
+export default function SellerLayout({ children }: { children: ReactNode }) {
+  const session = mockSellerSession;
+
+  if (!session || session.role !== "supplier") {
+    throw new Error("Seller area requires an authenticated supplier session");
+  }
+
+  return (
+    <div className="seller-layout">
+      <aside className="seller-sidebar">
+        <div className="seller-profile">
+          <span className="seller-profile__badge">Seller workspace</span>
+          <strong className="seller-profile__name">{session.companyName}</strong>
+          <span className="seller-profile__meta">{session.contactName}</span>
+          <span className="seller-profile__meta seller-profile__meta--muted">{session.email}</span>
+        </div>
+
+        <SellerNavigation items={navigationItems} />
+
+        <Link className="button-secondary" href="/">
+          ← Back to home
+        </Link>
+      </aside>
+
+      <div className="seller-content">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/app/seller/navigation.tsx
+++ b/apps/web/app/seller/navigation.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type NavigationItem = {
+  href: string;
+  label: string;
+};
+
+type Props = {
+  items: NavigationItem[];
+};
+
+export function SellerNavigation({ items }: Props) {
+  const pathname = usePathname();
+
+  return (
+    <nav className="seller-nav" aria-label="Seller navigation">
+      <ul>
+        {items.map((item) => {
+          const isActive = pathname === item.href || pathname?.startsWith(`${item.href}/`);
+          return (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                className={isActive ? "seller-nav__link seller-nav__link--active" : "seller-nav__link"}
+              >
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/web/app/seller/reviews/page.tsx
+++ b/apps/web/app/seller/reviews/page.tsx
@@ -1,0 +1,121 @@
+import Link from "next/link";
+
+import { api, ApiReview, SupplierReviewsPayload } from "@/lib/api";
+
+import { mockSellerSession } from "../layout";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+export default async function SellerReviewsPage() {
+  const session = mockSellerSession;
+
+  let payload: SupplierReviewsPayload | null = null;
+  let error: string | null = null;
+
+  try {
+    payload = await api.listSupplierReviews(session.companyId);
+  } catch (err) {
+    console.error("Failed to load supplier reviews", err);
+    error = (err as Error)?.message || "Unable to load reviews";
+  }
+
+  const reviews: ApiReview[] = payload?.reviews ?? [];
+  const average = payload?.avg ?? 0;
+
+  return (
+    <main className="detail-page">
+      <header className="detail-header">
+        <div>
+          <p className="eyebrow">Reputation</p>
+          <h1>Buyer feedback</h1>
+          <p className="section-subtitle">Track the reviews buyers have shared about your fulfilment performance.</p>
+        </div>
+        <Link className="button-secondary" href="/seller/dashboard">
+          ← Back to dashboard
+        </Link>
+      </header>
+
+      {error && <div className="alert alert--error">{error}</div>}
+
+      <section className="card card--compact">
+        <div className="section-heading">
+          <div>
+            <h2>Average rating</h2>
+            <p className="section-subtitle">Rolling score based on all captured reviews.</p>
+          </div>
+          <span className="badge-inline">{reviews.length} reviews</span>
+        </div>
+
+        <div className="review-scorecard">
+          <div className="review-scorecard__value">{average.toFixed(2)}</div>
+          <div className="review-scorecard__meta">Out of 5</div>
+        </div>
+      </section>
+
+      <section className="card">
+        <div className="section-heading">
+          <div>
+            <h2>Review log</h2>
+            <p className="section-subtitle">Full history of buyer commentary linked to orders.</p>
+          </div>
+        </div>
+
+        {reviews.length ? (
+          <div className="table-wrapper">
+            <table className="rfq-table">
+              <thead>
+                <tr>
+                  <th>Rating</th>
+                  <th>Comment</th>
+                  <th>Order</th>
+                  <th>Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {reviews
+                  .slice()
+                  .sort((a, b) => {
+                    const aDate = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+                    const bDate = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+                    return bDate - aDate;
+                  })
+                  .map((review, index) => (
+                    <tr key={`${review.id || index}-${review.orderId || "unknown"}`}>
+                      <td>{review.rating}</td>
+                      <td>{review.comment || review.text || "—"}</td>
+                      <td>
+                        {review.orderId ? (
+                          <Link className="link-muted" href={`/orders/${review.orderId}`}>
+                            {review.orderId}
+                          </Link>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td>{formatDate(review.createdAt)}</td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="empty-state">
+            <h3>No reviews collected</h3>
+            <p>Feedback will appear after orders close and buyers submit their experience.</p>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -177,6 +177,20 @@ export const api = {
     });
   },
 
+  async createQuote(payload: {
+    rfqId: string;
+    currency: string;
+    pricePerUnitMinor: number;
+    moq?: number | null;
+    leadTimeDays?: number | null;
+  }): Promise<ApiQuote> {
+    return request<ApiQuote>(`${API_BASE}/quotes`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  },
+
   async listOrders(): Promise<ApiOrder[]> {
     return request<ApiOrder[]>(`${API_BASE}/orders`, { cache: "no-store" });
   },


### PR DESCRIPTION
## Summary
- add a seller layout that enforces the mock supplier session and navigation
- implement the seller dashboard with RFQ visibility and quote submission
- build supporting contracts and reviews views plus API helpers for supplier workflows

## Testing
- pnpm --filter @tijaralink/web build *(fails: existing duplicate identifier in apps/web/app/suppliers/[companyId]/reviews/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f2989bc4832d99590ced320031d6