### PR TITLE
Add polished supplier and order views

### DIFF
--- a/apps/web/app/components/SiteHeader.tsx
+++ b/apps/web/app/components/SiteHeader.tsx
@@ -40,6 +40,9 @@ export default function SiteHeader() {
           <Link href="/orders" className={navLinkClassName(pathname?.startsWith("/orders") ?? false)}>
             Orders
           </Link>
+          <Link href="/contact" className={navLinkClassName(pathname?.startsWith("/contact") ?? false)}>
+            Contact
+          </Link>
         </nav>
         <div className="site-header__actions">
           {isHydrated && session ? (

--- a/apps/web/app/contact/page.tsx
+++ b/apps/web/app/contact/page.tsx
@@ -1,0 +1,74 @@
+// apps/web/app/contact/page.tsx
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Contact TijaraLink",
+};
+
+const CONTACT_CARDS = [
+  {
+    title: "Product & Platform",
+    description:
+      "Schedule a guided walkthrough of the buyer and supplier workspaces and learn how we can adapt to your current stack.",
+    email: "product@tijaralink.com",
+    cta: "Book a platform demo",
+    href: "mailto:product@tijaralink.com",
+  },
+  {
+    title: "Supplier Success",
+    description:
+      "Need help onboarding your sourcing team or verifying supplier credentials? Our success partners can assist within 24 hours.",
+    email: "success@tijaralink.com",
+    cta: "Talk to supplier success",
+    href: "mailto:success@tijaralink.com",
+  },
+  {
+    title: "Support & Escrow",
+    description:
+      "Questions about compliance, escrow release, or logistics milestones? Reach our support engineers any time.",
+    email: "support@tijaralink.com",
+    cta: "Open a support ticket",
+    href: "mailto:support@tijaralink.com",
+  },
+];
+
+export default function ContactPage() {
+  return (
+    <main className="page contact-page">
+      <section className="card hero">
+        <div className="hero__content">
+          <span className="hero__eyebrow">Connect with TijaraLink</span>
+          <h1 className="hero__title">We are ready to partner on your next trade lane.</h1>
+          <p className="hero__subtitle">
+            Choose the path that fits your team&apos;s needs or drop us a note and we&apos;ll route it to the right specialist within
+            one business day.
+          </p>
+          <div className="cta-row">
+            <Link className="button-primary" href="mailto:hello@tijaralink.com">
+              Email hello@tijaralink.com
+            </Link>
+            <Link className="button-secondary" href="/register">
+              Start your workspace
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="layout-grid contact-grid">
+        {CONTACT_CARDS.map((card) => (
+          <article key={card.title} className="card card--compact contact-card">
+            <header className="contact-card__header">
+              <h2>{card.title}</h2>
+              <p>{card.description}</p>
+            </header>
+            <p className="contact-card__email">{card.email}</p>
+            <a className="button-tertiary" href={card.href}>
+              {card.cta}
+            </a>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -233,6 +233,28 @@ main.page {
   background: rgba(148, 163, 184, 0.12);
 }
 
+.button-tertiary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px dashed rgba(37, 99, 235, 0.4);
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+  transition: border-color 150ms ease, color 150ms ease, background 150ms ease;
+}
+
+.button-tertiary:hover,
+.button-tertiary:focus-visible {
+  border-color: rgba(37, 99, 235, 0.7);
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--foreground);
+}
+
 main.auth-page {
   max-width: 520px;
   padding: 80px 24px 120px;
@@ -379,14 +401,203 @@ main.auth-page {
   font-size: 0.95rem;
 }
 
+.layout-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .layout-grid {
+    grid-template-columns: 2fr 1fr;
+  }
+}
+
+.stat-row {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.stat-card {
+  display: grid;
+  gap: 6px;
+  padding: 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: var(--shadow-md);
+}
+
+.stat-card__value {
+  margin: 0;
+  font-size: 1.85rem;
+  font-weight: 700;
+  color: var(--foreground);
+}
+
+.stat-card__hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.contact-grid {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.contact-card {
+  display: grid;
+  gap: 12px;
+}
+
+.contact-card__header h2 {
+  margin: 0;
+}
+
+.contact-card__header p {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+
+.contact-card__email {
+  margin: 0;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.suppliers-page .section-heading {
+  margin-bottom: 16px;
+}
+
+.supplier-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.supplier-card {
+  display: grid;
+  gap: 16px;
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: var(--shadow-md);
+}
+
+.supplier-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.supplier-card__header h3 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.supplier-card__header p {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+
+.supplier-card__rating span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.supplier-card__description {
+  margin: 0;
+  color: var(--foreground);
+}
+
+.supplier-card__highlight {
+  margin: 0;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.supplier-tags {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.supplier-tags li {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--foreground);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.supplier-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.orders-table td:nth-child(2),
+.orders-table th:nth-child(2) {
+  width: 160px;
+}
+
+.supplier-detail__grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.supplier-detail__grid article {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow-md);
+}
+
+.supplier-detail__grid h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.supplier-detail__grid ul {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.supplier-detail__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 18px;
 }
 
-@layer base {
-  :root {
+:root {
     color-scheme: light;
     --font-sans: "Poppins", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
 
@@ -404,9 +615,10 @@ main.auth-page {
     --card: 0 0% 100%;
     --card-foreground: 222 47% 11%;
 
-    --border: 215 20% 65%;
-    --input: 215 20% 78%;
-    --ring: 221 83% 53%;
+  --border: 215 20% 65%;
+  --input: 215 20% 78%;
+  --ring: 221 83% 53%;
+}
 
 .rfq-table thead {
   background: rgba(37, 99, 235, 0.06);
@@ -690,17 +902,6 @@ a.link-muted:hover {
 .footer-note {
   font-size: 13px;
   color: var(--muted);
-}
-
-    --radius-lg: 24px;
-    --radius-md: 16px;
-    --radius-sm: 12px;
-  }
-
-  body {
-    @apply min-h-screen bg-body-gradient text-foreground antialiased;
-    font-family: var(--font-sans);
-  }
 }
 
 .buyer-shell {

--- a/apps/web/app/orders/page.tsx
+++ b/apps/web/app/orders/page.tsx
@@ -1,0 +1,159 @@
+// apps/web/app/orders/page.tsx
+import Link from "next/link";
+
+import { api, ApiOrder } from "@/lib/api";
+
+export const dynamic = "force-dynamic";
+
+function formatCurrency(totalMinor?: number, currency?: string | null) {
+  if (typeof totalMinor !== "number") return "—";
+  const amount = totalMinor / 100;
+  return `${currency ?? "USD"} ${amount.toLocaleString(undefined, { minimumFractionDigits: 2 })}`;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+function statusVariant(status?: string | null) {
+  const normalized = String(status ?? "draft").toLowerCase();
+  if (/(delivered|completed|released)/.test(normalized)) return "status-pill status-pill--approved";
+  if (/(processing|customs|transit|active|in_progress)/.test(normalized)) return "status-pill status-pill--pending";
+  if (/(cancel|rejected|failed)/.test(normalized)) return "status-pill status-pill--closed";
+  return "status-pill status-pill--draft";
+}
+
+function summarizeTotals(orders: ApiOrder[]) {
+  return orders.reduce(
+    (acc, order) => {
+      acc.total += (order.totalMinor ?? 0) / 100;
+      if ((order.status ?? "").toLowerCase().includes("deliver")) {
+        acc.delivered += 1;
+      }
+      if (!order.escrow?.released) {
+        acc.escrowHeld += (order.escrow?.heldMinor ?? 0) / 100;
+      }
+      return acc;
+    },
+    { total: 0, delivered: 0, escrowHeld: 0 },
+  );
+}
+
+export default async function OrdersPage() {
+  let orders: ApiOrder[] = [];
+  let error: string | null = null;
+
+  try {
+    orders = await api.listOrders();
+  } catch (err) {
+    console.error("Failed to load orders", err);
+    error = (err as Error)?.message || "Unable to load orders";
+  }
+
+  const stats = summarizeTotals(orders);
+
+  return (
+    <main className="detail-page orders-page">
+      <header className="detail-header">
+        <div>
+          <p className="eyebrow">Operations overview</p>
+          <h1>Orders & fulfilment</h1>
+          <p className="section-subtitle">
+            Track every stage from quote acceptance to delivery. Connect logistics and compliance in a single workspace.
+          </p>
+        </div>
+        <Link className="button-secondary" href="/rfq">
+          ← Back to RFQs
+        </Link>
+      </header>
+
+      {error ? <div className="alert alert--error">{error}</div> : null}
+
+      <section className="card orders-summary">
+        <div className="stat-row">
+          <div className="stat-card">
+            <p className="eyebrow">Active orders</p>
+            <p className="stat-card__value">{orders.length}</p>
+            <p className="stat-card__hint">Synced directly from the TijaraLink API.</p>
+          </div>
+          <div className="stat-card">
+            <p className="eyebrow">Total value</p>
+            <p className="stat-card__value">USD {stats.total.toLocaleString(undefined, { minimumFractionDigits: 2 })}</p>
+            <p className="stat-card__hint">Aggregate based on current order totals.</p>
+          </div>
+          <div className="stat-card">
+            <p className="eyebrow">Delivered</p>
+            <p className="stat-card__value">{stats.delivered}</p>
+            <p className="stat-card__hint">Orders flagged as delivered or completed.</p>
+          </div>
+          <div className="stat-card">
+            <p className="eyebrow">Escrow held</p>
+            <p className="stat-card__value">USD {stats.escrowHeld.toLocaleString(undefined, { minimumFractionDigits: 2 })}</p>
+            <p className="stat-card__hint">Funds available for release once customs clears.</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="card">
+        <div className="section-heading">
+          <div>
+            <h2>Orders</h2>
+            <p className="section-subtitle">Dive into each order to release escrow, update shipments, or sign contracts.</p>
+          </div>
+        </div>
+
+        {orders.length ? (
+          <div className="table-wrapper">
+            <table className="rfq-table orders-table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Status</th>
+                  <th>Buyer</th>
+                  <th>Supplier</th>
+                  <th>Total</th>
+                  <th>Created</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {orders.map((order) => (
+                  <tr key={order.id}>
+                    <td className="mono">{order.id}</td>
+                    <td>
+                      <span className={statusVariant(order.status)}>{order.status ?? "Pending"}</span>
+                    </td>
+                    <td>{order.buyerCompanyId ?? order.buyerId ?? "—"}</td>
+                    <td>{order.supplierCompanyId ?? order.supplierId ?? "—"}</td>
+                    <td>{formatCurrency(order.totalMinor, order.totalCurrency)}</td>
+                    <td>{formatDate(order.createdAt)}</td>
+                    <td>
+                      <Link className="link-muted" href={`/orders/${order.id}`}>
+                        View details
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="empty-state">
+            <h3>No orders yet</h3>
+            <p>Accept a supplier quote to convert it into an order and track fulfilment from this dashboard.</p>
+            <Link className="button-primary" href="/rfq">
+              Review RFQs
+            </Link>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -62,13 +62,13 @@ export default async function Home() {
                 <p className="mt-2 text-sm text-slate-300">Access verified suppliers and orchestrate compliant sourcing.</p>
                 <div className="mt-4 flex flex-wrap gap-3">
                   <Link
-                    href="/buyers/login"
+                    href="/login?role=buyer"
                     className="inline-flex items-center justify-center rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400"
                   >
                     Buyer Login
                   </Link>
                   <Link
-                    href="/buyers/register"
+                    href="/register?role=buyer"
                     className="inline-flex items-center justify-center rounded-full border border-emerald-400/60 px-4 py-2 text-sm font-semibold text-emerald-200 transition hover:border-emerald-300 hover:text-emerald-100"
                   >
                     Create Buyer Account
@@ -81,13 +81,13 @@ export default async function Home() {
                 <p className="mt-2 text-sm text-slate-300">Showcase capabilities and secure recurring export demand.</p>
                 <div className="mt-4 flex flex-wrap gap-3">
                   <Link
-                    href="/suppliers/login"
+                    href="/login?role=seller"
                     className="inline-flex items-center justify-center rounded-full bg-amber-400 px-4 py-2 text-sm font-semibold text-amber-950 transition hover:bg-amber-300"
                   >
                     Supplier Login
                   </Link>
                   <Link
-                    href="/suppliers/register"
+                    href="/register?role=seller"
                     className="inline-flex items-center justify-center rounded-full border border-amber-300/60 px-4 py-2 text-sm font-semibold text-amber-200 transition hover:border-amber-200 hover:text-amber-100"
                   >
                     Join as Supplier

--- a/apps/web/app/seller/contracts/page.tsx
+++ b/apps/web/app/seller/contracts/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import SignContractButton from "@/app/components/SignContractButton";
 import { api, ApiOrder } from "@/lib/api";
 
-import { mockSellerSession } from "../layout";
+import { mockSellerSession } from "../session";
 
 export const dynamic = "force-dynamic";
 

--- a/apps/web/app/seller/layout.tsx
+++ b/apps/web/app/seller/layout.tsx
@@ -2,24 +2,7 @@ import Link from "next/link";
 import { ReactNode } from "react";
 
 import { SellerNavigation } from "./navigation";
-
-export type SellerSession = {
-  id: string;
-  companyId: string;
-  companyName: string;
-  contactName: string;
-  email: string;
-  role: "supplier";
-};
-
-export const mockSellerSession: SellerSession = {
-  id: "seller-user-001",
-  companyId: "demo-supplier-tr",
-  companyName: "Demo Supplier TR",
-  contactName: "Amal Yılmaz",
-  email: "amal@demosuppliertr.com",
-  role: "supplier",
-};
+import { mockSellerSession } from "./session";
 
 const navigationItems = [
   { href: "/seller/dashboard", label: "Dashboard" },

--- a/apps/web/app/seller/reviews/page.tsx
+++ b/apps/web/app/seller/reviews/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import { api, ApiReview, SupplierReviewsPayload } from "@/lib/api";
 
-import { mockSellerSession } from "../layout";
+import { mockSellerSession } from "../session";
 
 export const dynamic = "force-dynamic";
 

--- a/apps/web/app/seller/session.ts
+++ b/apps/web/app/seller/session.ts
@@ -1,0 +1,17 @@
+export type SellerSession = {
+  id: string;
+  companyId: string;
+  companyName: string;
+  contactName: string;
+  email: string;
+  role: "supplier";
+};
+
+export const mockSellerSession: SellerSession = {
+  id: "seller-user-001",
+  companyId: "demo-supplier-tr",
+  companyName: "Demo Supplier TR",
+  contactName: "Amal Yılmaz",
+  email: "amal@demosuppliertr.com",
+  role: "supplier",
+};

--- a/apps/web/app/suppliers/[companyId]/page.tsx
+++ b/apps/web/app/suppliers/[companyId]/page.tsx
@@ -1,0 +1,116 @@
+// apps/web/app/suppliers/[companyId]/page.tsx
+import Link from "next/link";
+
+import { api } from "@/lib/api";
+
+import { SUPPLIER_PROFILES } from "../data";
+
+export const dynamic = "force-dynamic";
+
+type Params = { params: { companyId: string } };
+
+export default async function SupplierDetailPage({ params }: Params) {
+  const supplier = SUPPLIER_PROFILES.find((item) => item.companyId === params.companyId);
+
+  if (!supplier) {
+    return (
+      <main className="detail-page">
+        <header className="detail-header">
+          <div>
+            <p className="eyebrow">Supplier profile</p>
+            <h1>Profile not found</h1>
+            <p className="section-subtitle">This supplier is not yet activated inside TijaraLink.</p>
+          </div>
+          <Link className="button-secondary" href="/suppliers">
+            ← Back to suppliers
+          </Link>
+        </header>
+      </main>
+    );
+  }
+
+  let rating: number | null = null;
+  let reviewCount = 0;
+  try {
+    const reviews = await api.listSupplierReviews(supplier.companyId);
+    rating = reviews.avg;
+    reviewCount = reviews.reviews.length;
+  } catch (error) {
+    console.warn(`Unable to fetch supplier reviews for ${supplier.companyId}`, error);
+  }
+
+  return (
+    <main className="detail-page supplier-detail">
+      <header className="detail-header">
+        <div>
+          <p className="eyebrow">Supplier profile</p>
+          <h1>{supplier.name}</h1>
+          <p className="section-subtitle">
+            {supplier.location} • Focused on {supplier.focus.join(", ")}. Response time {supplier.responseTime}.
+          </p>
+        </div>
+        <Link className="button-secondary" href="/suppliers">
+          ← Back to suppliers
+        </Link>
+      </header>
+
+      <section className="card">
+        <div className="section-heading">
+          <div>
+            <h2>Capability snapshot</h2>
+            <p className="section-subtitle">Operational depth based on latest onboarding audit.</p>
+          </div>
+          {typeof rating === "number" ? (
+            <span className="badge-inline">Quality score ★ {rating.toFixed(1)} ({reviewCount})</span>
+          ) : (
+            <span className="badge-inline">New supplier</span>
+          )}
+        </div>
+
+        <div className="supplier-detail__grid">
+          <article>
+            <h3>Core services</h3>
+            <ul>
+              {supplier.capabilities.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </article>
+          <article>
+            <h3>Compliance & certifications</h3>
+            <ul>
+              {supplier.compliance.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </article>
+          <article>
+            <h3>Primary markets</h3>
+            <ul>
+              {supplier.markets.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section className="card">
+        <div className="section-heading">
+          <div>
+            <h2>Work with {supplier.name.split(" ")[0]}</h2>
+            <p className="section-subtitle">Initiate diligence, invite to RFQs, or schedule a discovery call.</p>
+          </div>
+        </div>
+        <div className="supplier-detail__cta">
+          <Link className="button-primary" href={`/rfq?prefillSupplier=${supplier.companyId}`}>
+            Invite to an RFQ
+          </Link>
+          <Link className="button-tertiary" href="mailto:success@tijaralink.com">
+            Arrange onboarding session
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/suppliers/data.ts
+++ b/apps/web/app/suppliers/data.ts
@@ -1,0 +1,54 @@
+export type SupplierProfile = {
+  companyId: string;
+  name: string;
+  location: string;
+  focus: string[];
+  responseTime: string;
+  description: string;
+  capabilities: string[];
+  compliance: string[];
+  markets: string[];
+  highlights: string;
+};
+
+export const SUPPLIER_PROFILES: SupplierProfile[] = [
+  {
+    companyId: "00000000-0000-0000-0000-000000000002",
+    name: "Bosporus Materials Cooperative",
+    location: "Istanbul, Türkiye",
+    focus: ["Construction", "Cement", "Steel"],
+    responseTime: "< 4h",
+    description:
+      "Specialised in large-scale construction materials with bonded warehouse options and bilingual trade teams.",
+    capabilities: ["Bulk cement bagging", "Rebar cutting & bending", "On-dock QC inspections"],
+    compliance: ["ISO 9001", "REACH", "EUR.1 certified"],
+    markets: ["GCC", "Levant", "North Africa"],
+    highlights: "Manages bonded warehouse capacity across Marmara ports for rapid cross-docking.",
+  },
+  {
+    companyId: "demo-agri-001",
+    name: "Maghreb Agro Collective",
+    location: "Casablanca, Morocco",
+    focus: ["Agri Commodities", "Fresh Produce", "Cold Chain"],
+    responseTime: "Same day",
+    description:
+      "Exporting citrus, olives, and pulses with HACCP certified packing facilities across three ports.",
+    capabilities: ["Controlled-atmosphere storage", "24/7 QC lab", "Multi-temperature fleet"],
+    compliance: ["HACCP", "GlobalG.A.P.", "IFS Logistics"],
+    markets: ["EU", "Gulf", "West Africa"],
+    highlights: "Runs origin consolidation hubs that integrate directly with TijaraLink escrow milestones.",
+  },
+  {
+    companyId: "demo-textile-001",
+    name: "Levant Textile Guild",
+    location: "Amman, Jordan",
+    focus: ["Technical Textiles", "Protective Gear"],
+    responseTime: "< 8h",
+    description:
+      "Provides ISO 9001 compliant manufacturing with short production runs and digital QC reporting.",
+    capabilities: ["Laser cutting", "RF welding", "Custom embroidery"],
+    compliance: ["ISO 9001", "CE Mark", "Wrap Gold"],
+    markets: ["EU", "North America", "MENA"],
+    highlights: "Digital QA stack integrates with TijaraLink review workflows for instant buyer sign-off.",
+  },
+];

--- a/apps/web/app/suppliers/page.tsx
+++ b/apps/web/app/suppliers/page.tsx
@@ -1,0 +1,98 @@
+// apps/web/app/suppliers/page.tsx
+import Link from "next/link";
+
+import { api } from "@/lib/api";
+
+import { SUPPLIER_PROFILES, type SupplierProfile } from "./data";
+
+export const dynamic = "force-dynamic";
+
+type SupplierWithRating = SupplierProfile & { rating: number | null; reviewCount: number };
+
+async function withReviews(): Promise<SupplierWithRating[]> {
+  return Promise.all(
+    SUPPLIER_PROFILES.map(async (supplier) => {
+      try {
+        const reviews = await api.listSupplierReviews(supplier.companyId);
+        return {
+          ...supplier,
+          rating: reviews.avg,
+          reviewCount: reviews.reviews.length,
+        };
+      } catch (error) {
+        console.warn(`Unable to fetch reviews for ${supplier.companyId}`, error);
+        return {
+          ...supplier,
+          rating: null,
+          reviewCount: 0,
+        };
+      }
+    }),
+  );
+}
+
+export default async function SuppliersPage() {
+  const suppliers = await withReviews();
+
+  return (
+    <main className="detail-page suppliers-page">
+      <header className="detail-header">
+        <div>
+          <p className="eyebrow">Supplier network</p>
+          <h1>Trusted exporters ready to collaborate</h1>
+          <p className="section-subtitle">
+            Every supplier listed below operates inside TijaraLink&apos;s compliance framework with escrow-backed fulfilment and
+            transparent milestone tracking.
+          </p>
+        </div>
+        <Link className="button-primary" href="/register?role=seller">
+          Become a supplier
+        </Link>
+      </header>
+
+      <section className="card">
+        <div className="section-heading">
+          <div>
+            <h2>Featured suppliers</h2>
+            <p className="section-subtitle">Review capabilities, response times, and quality scores at a glance.</p>
+          </div>
+        </div>
+
+        <div className="supplier-grid">
+          {suppliers.map((supplier) => (
+            <article key={supplier.companyId} className="supplier-card">
+              <header className="supplier-card__header">
+                <div>
+                  <h3>{supplier.name}</h3>
+                  <p>{supplier.location}</p>
+                </div>
+                <div className="supplier-card__rating">
+                  {typeof supplier.rating === "number" ? (
+                    <span>
+                      ★ {supplier.rating.toFixed(1)} <small>({supplier.reviewCount})</small>
+                    </span>
+                  ) : (
+                    <span>New to TijaraLink</span>
+                  )}
+                </div>
+              </header>
+              <p className="supplier-card__description">{supplier.description}</p>
+              <p className="supplier-card__highlight">{supplier.highlights}</p>
+              <ul className="supplier-tags">
+                {supplier.focus.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+              <footer className="supplier-card__footer">
+                <span className="badge-inline">Response time {supplier.responseTime}</span>
+                <Link className="button-tertiary" href={`/suppliers/${supplier.companyId}`}>
+                  View profile
+                </Link>
+              </footer>
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a supplier catalogue backed by mock data, detail pages, and API-powered review summaries
- introduce an orders dashboard, contact hub, and update navigation links to working routes
- extend shared styling utilities and centralize the mock seller session for reuse

## Testing
- pnpm --filter @tijaralink/web build *(fails: login/register client routes require suspense boundaries)*

------
https://chatgpt.com/codex/tasks/task_e_68e428c6195c832db21b11bd16251565