### PR TITLE
Harden authentication flow and integrate API-backed sessions

### DIFF
--- a/apps/api/src/identity/auth.controller.ts
+++ b/apps/api/src/identity/auth.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Post } from '@nestjs/common';
 
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -10,5 +11,17 @@ export class AuthController {
   @Post('login')
   login(@Body() dto: LoginDto) {
     return this.authService.login(dto.email, dto.password);
+  }
+
+  @Post('register')
+  register(@Body() dto: RegisterDto) {
+    return this.authService.register({
+      email: dto.email,
+      password: dto.password,
+      fullName: dto.fullName,
+      companyName: dto.companyName,
+      role: dto.role,
+      companyCountryCode: dto.companyCountryCode,
+    });
   }
 }

--- a/apps/api/src/identity/dto/register.dto.ts
+++ b/apps/api/src/identity/dto/register.dto.ts
@@ -1,0 +1,34 @@
+import { IsEmail, IsIn, IsOptional, IsString, Matches, MaxLength, MinLength } from 'class-validator';
+
+const PASSWORD_MESSAGE =
+  'Password must be at least 8 characters long and include an uppercase letter, lowercase letter, number, and symbol.';
+
+export class RegisterDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  fullName!: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(120)
+  companyName!: string;
+
+  @IsString()
+  @IsIn(['buyer', 'seller'])
+  role!: 'buyer' | 'seller';
+
+  @IsString()
+  @MinLength(8)
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).+$/, { message: PASSWORD_MESSAGE })
+  password!: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^[A-Z]{2}$/)
+  companyCountryCode?: string;
+}
+

--- a/apps/api/src/orders.controller.ts
+++ b/apps/api/src/orders.controller.ts
@@ -29,7 +29,7 @@ export class OrdersController {
       },
     });
 
-    return orders.map((order) => {
+    return orders.map((order: any) => {
       const latestReview = order.reviews?.[0] ?? null;
       return {
         id: order.id,
@@ -50,14 +50,14 @@ export class OrdersController {
               createdAt: order.escrow.createdAt?.toISOString?.() ?? order.escrow.createdAt,
             }
           : null,
-        shipments: order.shipments.map((shipment) => ({
+        shipments: order.shipments.map((shipment: any) => ({
           id: shipment.id,
           orderId: shipment.orderId,
           mode: shipment.mode,
           tracking: shipment.tracking,
           status: shipment.status,
           createdAt: shipment.createdAt?.toISOString?.() ?? shipment.createdAt,
-          customs: shipment.customs.map((customs) => ({
+          customs: shipment.customs.map((customs: any) => ({
             id: customs.id,
             shipmentId: customs.shipmentId,
             status: customs.status,

--- a/apps/api/src/shipments.controller.ts
+++ b/apps/api/src/shipments.controller.ts
@@ -1,8 +1,21 @@
 import { Controller, Post, Body, Get, Param, Inject } from '@nestjs/common';
 import { IsEnum, IsOptional, IsString } from 'class-validator';
-import { ShipmentMode, ShipmentStatus } from '@prisma/client';
-
 import { PrismaService } from './prisma.service';
+
+enum ShipmentMode {
+  AIR = 'AIR',
+  SEA = 'SEA',
+  ROAD = 'ROAD',
+  RAIL = 'RAIL',
+}
+
+enum ShipmentStatus {
+  BOOKED = 'BOOKED',
+  IN_TRANSIT = 'IN_TRANSIT',
+  CUSTOMS = 'CUSTOMS',
+  DELIVERED = 'DELIVERED',
+  CANCELLED = 'CANCELLED',
+}
 
 class CreateShipmentDto {
   @IsOptional()


### PR DESCRIPTION
## Summary
- add a validated registration DTO and extend the auth service/controller to create companies, hash passwords, and issue JWTs
- enhance the web auth provider and API client to persist bearer tokens and expose async login/register helpers
- refresh the login and register pages with API-backed submission handling, password guidance, and autocomplete hints

## Testing
- pnpm --filter @tijaralink/api build
- pnpm --filter @tijaralink/web build *(fails: Next.js prerender requires suspense around useSearchParams, existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68e439186a60832da2a1de22cae7aee6