### PR TITLE
Add admin authentication guard and secure dashboards

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -42,6 +42,19 @@ async function main() {
     },
   });
 
+  await prisma.user.upsert({
+    where: { id: '00000000-0000-0000-0000-000000000099' },
+    update: { password: demoPassword },
+    create: {
+      id: '00000000-0000-0000-0000-000000000099',
+      companyId: buyer.id,
+      email: 'admin@demo.ps',
+      fullName: 'Admin One',
+      role: 'ADMIN',
+      password: demoPassword,
+    },
+  });
+
   await prisma.product.createMany({
     data: [
       { companyId: supplier.id, nameI18n: { en: 'Cement (50kg)', ar: 'أسمنت (50كج)', tr: 'Çimento (50kg)' }, hsCode: '2523.29', unit: 'bag' },

--- a/apps/web/app/admin/rfq/page.tsx
+++ b/apps/web/app/admin/rfq/page.tsx
@@ -1,12 +1,14 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import Link from "next/link";
 
-import { api, ApiQuote, ApiRfq } from "@/lib/api";
+import { useRequireRole } from "../../hooks/useRequireRole";
+import { api, type ApiQuote, type ApiRfq } from "@/lib/api";
 
-export const dynamic = "force-dynamic";
-
-function formatDate(value?: string | null) {
-  if (!value) return "—";
-  const date = new Date(value);
+function formatDate(input?: string | null) {
+  if (!input) return "—";
+  const date = new Date(input);
   if (Number.isNaN(date.getTime())) return "—";
   return new Intl.DateTimeFormat("en", {
     month: "short",
@@ -19,35 +21,88 @@ function toStatusKey(value?: string | null) {
   return String(value || "").toUpperCase();
 }
 
-export default async function AdminRfqPage() {
-  let rfqs: ApiRfq[] = [];
-  let error: string | null = null;
-  const quotes: Record<string, ApiQuote[]> = {};
+type QuotesMap = Record<string, ApiQuote[]>;
 
-  try {
-    rfqs = await api.listRfq();
-  } catch (err) {
-    console.error("Failed to load RFQs", err);
-    error = (err as Error)?.message || "Unable to load RFQs";
-  }
+export default function AdminRfqPage() {
+  const { canRender, isHydrated } = useRequireRole("admin", { redirectTo: "/admin/rfq" });
+  const [rfqs, setRfqs] = useState<ApiRfq[]>([]);
+  const [quotesMap, setQuotesMap] = useState<QuotesMap>({});
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setLoading] = useState(true);
 
-  await Promise.all(
-    rfqs.map(async (rfq) => {
+  useEffect(() => {
+    if (!canRender) return;
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+
       try {
-        quotes[rfq.id] = await api.listQuotesByRfq(rfq.id);
+        const rfqResponse = await api.listRfq();
+        if (!cancelled) {
+          setRfqs(rfqResponse);
+        }
+
+        const entries = await Promise.all(
+          rfqResponse.map(async (rfq) => {
+            try {
+              const quotes = await api.listQuotesByRfq(rfq.id);
+              return [rfq.id, quotes] as const;
+            } catch (err) {
+              console.error("Failed to load quotes for", rfq.id, err);
+              return [rfq.id, []] as const;
+            }
+          }),
+        );
+
+        if (!cancelled) {
+          setQuotesMap(Object.fromEntries(entries));
+        }
       } catch (err) {
-        console.error("Failed to load quotes for RFQ", rfq.id, err);
-        quotes[rfq.id] = [];
+        console.error("Failed to load RFQs", err);
+        if (!cancelled) {
+          setError((err as Error)?.message || "Unable to load RFQs");
+          setRfqs([]);
+          setQuotesMap({});
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
-    })
-  );
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [canRender]);
+
+  if (!isHydrated || !canRender) {
+    return (
+      <main className="detail-page">
+        <header className="detail-header">
+          <div>
+            <p className="eyebrow">RFQ administration</p>
+            <h1>RFQs</h1>
+          </div>
+        </header>
+        <section className="card">
+          <h2>Verifying access…</h2>
+          <p>Please wait while we confirm your permissions.</p>
+        </section>
+      </main>
+    );
+  }
 
   return (
     <main className="detail-page">
       <header className="detail-header">
         <div>
           <p className="eyebrow">RFQ administration</p>
-          <h1>All RFQs</h1>
+          <h1>RFQs</h1>
         </div>
         <Link className="button-secondary" href="/admin">
           ← Back to admin
@@ -59,13 +114,18 @@ export default async function AdminRfqPage() {
       <section className="card">
         <div className="section-heading">
           <div>
-            <h2>Pipeline</h2>
-            <p className="section-subtitle">Review sourcing demand and jump into supplier collaboration.</p>
+            <h2>Live RFQs</h2>
+            <p className="section-subtitle">All demand captured from buyers. Open any request to inspect quotes.</p>
           </div>
-          <span className="badge-inline">{rfqs.length} RFQs</span>
+          <span className="badge-inline">{rfqs.length} total</span>
         </div>
 
-        {rfqs.length ? (
+        {isLoading ? (
+          <div className="empty-state">
+            <h3>Loading RFQs…</h3>
+            <p>Retrieving the latest sourcing pipeline.</p>
+          </div>
+        ) : rfqs.length ? (
           <div className="table-wrapper">
             <table className="rfq-table">
               <thead>
@@ -73,26 +133,25 @@ export default async function AdminRfqPage() {
                   <th>ID</th>
                   <th>Title</th>
                   <th>Status</th>
-                  <th>Quotes</th>
                   <th>Destination</th>
+                  <th>Quotes</th>
                   <th>Created</th>
                   <th></th>
                 </tr>
               </thead>
               <tbody>
                 {rfqs.map((rfq) => {
-                  const rfqQuotes = quotes[rfq.id] || [];
-                  const accepted = rfqQuotes.filter((quote) => /ACCEPTED/.test(toStatusKey(quote.status))).length;
-
+                  const quotes = quotesMap[rfq.id] || [];
+                  const accepted = quotes.filter((quote) => /ACCEPTED/.test(toStatusKey(quote.status))).length;
                   return (
                     <tr key={rfq.id}>
                       <td className="mono">{rfq.id}</td>
                       <td>{rfq.title}</td>
                       <td>{rfq.status || "OPEN"}</td>
-                      <td>
-                        {accepted}/{rfqQuotes.length}
-                      </td>
                       <td>{rfq.destinationCountry || "—"}</td>
+                      <td>
+                        {accepted}/{quotes.length}
+                      </td>
                       <td>{formatDate(rfq.createdAt)}</td>
                       <td>
                         <Link className="link-muted" href={`/rfq/${rfq.id}`}>
@@ -107,11 +166,12 @@ export default async function AdminRfqPage() {
           </div>
         ) : (
           <div className="empty-state">
-            <h3>No RFQs available</h3>
-            <p>Use the buyer workspace to publish the first request for quote.</p>
+            <h3>No RFQs registered yet</h3>
+            <p>Publish a request from the landing page to begin receiving supplier responses.</p>
           </div>
         )}
       </section>
     </main>
   );
 }
+

--- a/apps/web/app/buyer/dashboard/page.tsx
+++ b/apps/web/app/buyer/dashboard/page.tsx
@@ -17,7 +17,8 @@ export default function BuyerDashboardPage() {
       return;
     }
     if (session.role !== "buyer") {
-      router.replace("/seller/dashboard");
+      const destination = session.role === "seller" ? "/seller/dashboard" : "/admin";
+      router.replace(destination);
     }
   }, [isHydrated, router, session]);
 

--- a/apps/web/app/components/HeroCtaButtons.tsx
+++ b/apps/web/app/components/HeroCtaButtons.tsx
@@ -20,15 +20,26 @@ export default function HeroCtaButtons() {
   }
 
   if (session) {
-    const dashboardHref = session.role === "seller" ? "/seller/dashboard" : "/buyer/dashboard";
+    const dashboardHref =
+      session.role === "seller"
+        ? "/seller/dashboard"
+        : session.role === "admin"
+          ? "/admin"
+          : "/buyer/dashboard";
     return (
       <>
         <Link className="button-primary" href={dashboardHref}>
           View Dashboard
         </Link>
-        <a className="button-secondary" href="#create-rfq">
-          Start a New RFQ
-        </a>
+        {session.role === "admin" ? (
+          <Link className="button-secondary" href="/admin/orders">
+            Review operations
+          </Link>
+        ) : (
+          <a className="button-secondary" href="#create-rfq">
+            Start a New RFQ
+          </a>
+        )}
       </>
     );
   }

--- a/apps/web/app/components/SiteHeader.tsx
+++ b/apps/web/app/components/SiteHeader.tsx
@@ -18,7 +18,7 @@ export default function SiteHeader() {
     router.push("/");
   };
 
-  const dashboardHref = session?.role === "seller" ? "/seller/dashboard" : "/buyer/dashboard";
+  const dashboardHref = session?.role === "seller" ? "/seller/dashboard" : session?.role === "admin" ? "/admin" : "/buyer/dashboard";
 
   return (
     <header className="site-header">

--- a/apps/web/app/hooks/useRequireRole.ts
+++ b/apps/web/app/hooks/useRequireRole.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { useRouter } from "next/navigation";
+
+import { useAuth, type UserRole } from "../providers/AuthProvider";
+
+type RequireRoleResult = {
+  canRender: boolean;
+  isHydrated: boolean;
+  session: ReturnType<typeof useAuth>["session"];
+};
+
+function fallbackRouteForRole(role: UserRole | undefined) {
+  if (role === "admin") return "/admin";
+  if (role === "seller") return "/seller/dashboard";
+  return "/buyer/dashboard";
+}
+
+export function useRequireRole(requiredRole: UserRole, options: { redirectTo?: string } = {}): RequireRoleResult {
+  const router = useRouter();
+  const { session, isHydrated } = useAuth();
+
+  useEffect(() => {
+    if (!isHydrated) return;
+
+    if (!session) {
+      const redirectTarget =
+        options.redirectTo ||
+        (typeof window !== "undefined"
+          ? `${window.location.pathname}${window.location.search}`
+          : undefined);
+      const redirectParam = redirectTarget ? `&redirect=${encodeURIComponent(redirectTarget)}` : "";
+      router.replace(`/login?role=${requiredRole}${redirectParam}`);
+      return;
+    }
+
+    if (session.role !== requiredRole) {
+      router.replace(fallbackRouteForRole(session.role));
+    }
+  }, [isHydrated, options.redirectTo, requiredRole, router, session]);
+
+  return useMemo(
+    () => ({
+      canRender: Boolean(isHydrated && session?.role === requiredRole),
+      isHydrated,
+      session,
+    }),
+    [isHydrated, requiredRole, session],
+  );
+}
+

--- a/apps/web/app/providers/AuthProvider.tsx
+++ b/apps/web/app/providers/AuthProvider.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 
 import { api, type ApiAuthClaims, type ApiAuthResponse, setAuthToken } from "../../lib/api";
 
-export type UserRole = "buyer" | "seller";
+export type UserRole = "buyer" | "seller" | "admin";
 
 type AuthSession = {
   token: string;
@@ -28,7 +28,7 @@ type RegisterPayload = {
   password: string;
   fullName: string;
   companyName: string;
-  role: UserRole;
+  role: Exclude<UserRole, "admin">;
   remember?: boolean;
 };
 
@@ -51,7 +51,14 @@ const SESSION_STORAGE_KEY = "tijara-link.session";
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 function mapApiRole(role: string): UserRole {
-  return role?.toUpperCase() === "SUPPLIER" ? "seller" : "buyer";
+  switch (role?.toUpperCase()) {
+    case "SUPPLIER":
+      return "seller";
+    case "ADMIN":
+      return "admin";
+    default:
+      return "buyer";
+  }
 }
 
 function claimsToSession(claims: ApiAuthClaims, token: string, expiresAt: string): AuthSession {
@@ -117,7 +124,7 @@ function authResponseToPersisted(response: ApiAuthResponse): PersistedSession {
   };
 }
 
-export default function AuthProvider({ children }: { children: React.ReactNode }) {
+export default function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<AuthSession | null>(null);
   const [isHydrated, setHydrated] = useState(false);
 

--- a/apps/web/app/seller/dashboard/page.tsx
+++ b/apps/web/app/seller/dashboard/page.tsx
@@ -17,7 +17,8 @@ export default function SellerDashboardPage() {
       return;
     }
     if (session.role !== "seller") {
-      router.replace("/buyer/dashboard");
+      const destination = session.role === "buyer" ? "/buyer/dashboard" : "/admin";
+      router.replace(destination);
     }
   }, [isHydrated, router, session]);
 


### PR DESCRIPTION
## Summary
- add an admin seed user and extend the web auth provider to understand the admin role
- update login, register, navigation, and dashboards to route admins correctly and handle suspenseful hydration
- convert admin pages to guarded client components with the new role hook and refreshed data loading

## Testing
- pnpm --filter @tijaralink/web build

------
https://chatgpt.com/codex/tasks/task_e_68e445b261ec832d873da06521c9c788